### PR TITLE
[Feat/Fix] #12 - TimerView UI 구현 및 navigationBar 폴더 누락 해결

### DIFF
--- a/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
+++ b/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		370A50862B8DCBC000BD691A /* TimerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370A50852B8DCBC000BD691A /* TimerModel.swift */; };
+		3710787F2B8DDE580049EB9C /* CircleProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3710787E2B8DDE580049EB9C /* CircleProgressBar.swift */; };
+		371078812B8E36A70049EB9C /* CAShapeLayer+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371078802B8E36A70049EB9C /* CAShapeLayer+Extension.swift */; };
+		371078852B8EC67F0049EB9C /* PobitNavigationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371078842B8EC67F0049EB9C /* PobitNavigationBarView.swift */; };
 		371078872B8ED52F0049EB9C /* LayoutLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371078862B8ED52F0049EB9C /* LayoutLiterals.swift */; };
 		37144C662B8C32D6008565C4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37144C652B8C32D6008565C4 /* AppDelegate.swift */; };
 		37144C682B8C32D6008565C4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37144C672B8C32D6008565C4 /* SceneDelegate.swift */; };
@@ -22,6 +25,8 @@
 		37144C972B8C5674008565C4 /* UITextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37144C962B8C5674008565C4 /* UITextField+Extension.swift */; };
 		37144C9A2B8C57AF008565C4 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 37144C992B8C57AF008565C4 /* SnapKit */; };
 		37144C9C2B8C57AF008565C4 /* SnapKit-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 37144C9B2B8C57AF008565C4 /* SnapKit-Dynamic */; };
+		374E7B752B8DBECE00BC9B26 /* TimerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374E7B742B8DBECE00BC9B26 /* TimerViewController.swift */; };
+		374E7B7A2B8DBF6C00BC9B26 /* TimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374E7B792B8DBF6C00BC9B26 /* TimerView.swift */; };
 		376B91AA2B8C681A004CBB16 /* Pretendard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376B91A92B8C681A004CBB16 /* Pretendard.swift */; };
 		376B91AC2B8C6835004CBB16 /* ColorLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376B91AB2B8C6835004CBB16 /* ColorLiterals.swift */; };
 		376B91B22B8C6ABA004CBB16 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 376B91AE2B8C6AB9004CBB16 /* Pretendard-Medium.otf */; };
@@ -29,10 +34,7 @@
 		376B91B52B8C6ABA004CBB16 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 376B91B12B8C6ABA004CBB16 /* Pretendard-Regular.otf */; };
 		376B91B72B8C6AF6004CBB16 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 376B91B62B8C6AF6004CBB16 /* Pretendard-SemiBold.otf */; };
 		376B91BA2B8CE6B6004CBB16 /* PobitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376B91B92B8CE6B6004CBB16 /* PobitButton.swift */; };
-		7306F5B02B8D66EE004E6055 /* NaviBar in Resources */ = {isa = PBXBuildFile; fileRef = 7306F5AF2B8D66EE004E6055 /* NaviBar */; };
 		73DFA21F2B8D8D8E00C381A7 /* UIAlertController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DFA21E2B8D8D8E00C381A7 /* UIAlertController+Extension.swift */; };
-		374E7B752B8DBECE00BC9B26 /* TimerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374E7B742B8DBECE00BC9B26 /* TimerViewController.swift */; };
-		374E7B7A2B8DBF6C00BC9B26 /* TimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374E7B792B8DBF6C00BC9B26 /* TimerView.swift */; };
 		E0C5B53E2B8D5B2700A77BAE /* DayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5B53D2B8D5B2700A77BAE /* DayButton.swift */; };
 		E0C5B5442B8D5D9A00A77BAE /* HStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5B5412B8D5D9900A77BAE /* HStackView.swift */; };
 		E0C5B5452B8D5D9A00A77BAE /* VStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5B5422B8D5D9A00A77BAE /* VStackView.swift */; };
@@ -52,6 +54,9 @@
 
 /* Begin PBXFileReference section */
 		370A50852B8DCBC000BD691A /* TimerModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TimerModel.swift; path = PomoHabit/Presentation/Timer/Controllers/TimerModel.swift; sourceTree = SOURCE_ROOT; };
+		3710787E2B8DDE580049EB9C /* CircleProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleProgressBar.swift; sourceTree = "<group>"; };
+		371078802B8E36A70049EB9C /* CAShapeLayer+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CAShapeLayer+Extension.swift"; sourceTree = "<group>"; };
+		371078842B8EC67F0049EB9C /* PobitNavigationBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PobitNavigationBarView.swift; sourceTree = "<group>"; };
 		371078862B8ED52F0049EB9C /* LayoutLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutLiterals.swift; sourceTree = "<group>"; };
 		37144C622B8C32D6008565C4 /* PomoHabit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PomoHabit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		37144C652B8C32D6008565C4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -66,6 +71,8 @@
 		37144C922B8C544D008565C4 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		37144C942B8C5472008565C4 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
 		37144C962B8C5674008565C4 /* UITextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
+		374E7B742B8DBECE00BC9B26 /* TimerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimerViewController.swift; path = PomoHabit/Presentation/Timer/Controllers/TimerViewController.swift; sourceTree = SOURCE_ROOT; };
+		374E7B792B8DBF6C00BC9B26 /* TimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimerView.swift; path = PomoHabit/Presentation/Timer/Views/TimerView.swift; sourceTree = SOURCE_ROOT; };
 		376B91A92B8C681A004CBB16 /* Pretendard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pretendard.swift; sourceTree = "<group>"; };
 		376B91AB2B8C6835004CBB16 /* ColorLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorLiterals.swift; sourceTree = "<group>"; };
 		376B91AE2B8C6AB9004CBB16 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
@@ -73,10 +80,7 @@
 		376B91B12B8C6ABA004CBB16 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		376B91B62B8C6AF6004CBB16 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		376B91B92B8CE6B6004CBB16 /* PobitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PobitButton.swift; sourceTree = "<group>"; };
-		7306F5AF2B8D66EE004E6055 /* NaviBar */ = {isa = PBXFileReference; lastKnownFileType = folder; path = NaviBar; sourceTree = "<group>"; };
 		73DFA21E2B8D8D8E00C381A7 /* UIAlertController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extension.swift"; sourceTree = "<group>"; };
-		374E7B742B8DBECE00BC9B26 /* TimerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimerViewController.swift; path = PomoHabit/Presentation/Timer/Controllers/TimerViewController.swift; sourceTree = SOURCE_ROOT; };
-		374E7B792B8DBF6C00BC9B26 /* TimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimerView.swift; path = PomoHabit/Presentation/Timer/Views/TimerView.swift; sourceTree = SOURCE_ROOT; };
 		E0C5B53D2B8D5B2700A77BAE /* DayButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayButton.swift; sourceTree = "<group>"; };
 		E0C5B5412B8D5D9900A77BAE /* HStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HStackView.swift; sourceTree = "<group>"; };
 		E0C5B5422B8D5D9A00A77BAE /* VStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VStackView.swift; sourceTree = "<group>"; };
@@ -111,6 +115,7 @@
 			isa = PBXGroup;
 			children = (
 				374E7B792B8DBF6C00BC9B26 /* TimerView.swift */,
+				3710787E2B8DDE580049EB9C /* CircleProgressBar.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -121,6 +126,14 @@
 				370A50852B8DCBC000BD691A /* TimerModel.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		371078832B8EC6590049EB9C /* NavigationBar */ = {
+			isa = PBXGroup;
+			children = (
+				371078842B8EC67F0049EB9C /* PobitNavigationBarView.swift */,
+			);
+			path = NavigationBar;
 			sourceTree = "<group>";
 		};
 		37144C592B8C32D6008565C4 = {
@@ -192,6 +205,7 @@
 				73DFA21E2B8D8D8E00C381A7 /* UIAlertController+Extension.swift */,
 				F85F8F582B8DE54F00E69922 /* Date+Extension.swift */,
 				F870D85B2B8EFF3900DA4659 /* UILabel+Extension.swift */,
+				371078802B8E36A70049EB9C /* CAShapeLayer+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -199,7 +213,7 @@
 		37144C7D2B8C3413008565C4 /* Components */ = {
 			isa = PBXGroup;
 			children = (
-				7306F5AF2B8D66EE004E6055 /* NaviBar */,
+				371078832B8EC6590049EB9C /* NavigationBar */,
 				E0C5B53F2B8D5D8300A77BAE /* StackViews */,
 				E0C5B53C2B8D5AC000A77BAE /* DayButton */,
 				F8E3CD362B8C7FB600712CBF /* Note */,
@@ -521,7 +535,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7306F5B02B8D66EE004E6055 /* NaviBar in Resources */,
 				37144C722B8C32D7008565C4 /* LaunchScreen.storyboard in Resources */,
 				376B91B32B8C6ABA004CBB16 /* Pretendard-Bold.otf in Resources */,
 				376B91B72B8C6AF6004CBB16 /* Pretendard-SemiBold.otf in Resources */,
@@ -546,6 +559,8 @@
 				37144C8C2B8C3582008565C4 /* UIViewController+Extension.swift in Sources */,
 				376B91BA2B8CE6B6004CBB16 /* PobitButton.swift in Sources */,
 				F85F8F592B8DE54F00E69922 /* Date+Extension.swift in Sources */,
+				3710787F2B8DDE580049EB9C /* CircleProgressBar.swift in Sources */,
+				371078852B8EC67F0049EB9C /* PobitNavigationBarView.swift in Sources */,
 				E0C5B5452B8D5D9A00A77BAE /* VStackView.swift in Sources */,
 				F85F8F612B8E25EE00E69922 /* HabbitInfoVIew.swift in Sources */,
 				374E7B752B8DBECE00BC9B26 /* TimerViewController.swift in Sources */,
@@ -562,6 +577,7 @@
 				F85F8F632B8E26E100E69922 /* ImageViewAndLabelView.swift in Sources */,
 				73DFA21F2B8D8D8E00C381A7 /* UIAlertController+Extension.swift in Sources */,
 				E0C5B5442B8D5D9A00A77BAE /* HStackView.swift in Sources */,
+				371078812B8E36A70049EB9C /* CAShapeLayer+Extension.swift in Sources */,
 				F8E3CD382B8C7FC900712CBF /* NoteView.swift in Sources */,
 				37144C682B8C32D6008565C4 /* SceneDelegate.swift in Sources */,
 				370A50862B8DCBC000BD691A /* TimerModel.swift in Sources */,

--- a/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
+++ b/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		370A50862B8DCBC000BD691A /* TimerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370A50852B8DCBC000BD691A /* TimerModel.swift */; };
+		371078872B8ED52F0049EB9C /* LayoutLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371078862B8ED52F0049EB9C /* LayoutLiterals.swift */; };
 		37144C662B8C32D6008565C4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37144C652B8C32D6008565C4 /* AppDelegate.swift */; };
 		37144C682B8C32D6008565C4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37144C672B8C32D6008565C4 /* SceneDelegate.swift */; };
 		37144C6A2B8C32D6008565C4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37144C692B8C32D6008565C4 /* ViewController.swift */; };
@@ -51,6 +52,7 @@
 
 /* Begin PBXFileReference section */
 		370A50852B8DCBC000BD691A /* TimerModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TimerModel.swift; path = PomoHabit/Presentation/Timer/Controllers/TimerModel.swift; sourceTree = SOURCE_ROOT; };
+		371078862B8ED52F0049EB9C /* LayoutLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutLiterals.swift; sourceTree = "<group>"; };
 		37144C622B8C32D6008565C4 /* PomoHabit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PomoHabit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		37144C652B8C32D6008565C4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		37144C672B8C32D6008565C4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -394,6 +396,7 @@
 			children = (
 				376B91A92B8C681A004CBB16 /* Pretendard.swift */,
 				376B91AB2B8C6835004CBB16 /* ColorLiterals.swift */,
+				371078862B8ED52F0049EB9C /* LayoutLiterals.swift */,
 			);
 			path = Literals;
 			sourceTree = "<group>";
@@ -549,6 +552,7 @@
 				37144C6A2B8C32D6008565C4 /* ViewController.swift in Sources */,
 				E0C5B53E2B8D5B2700A77BAE /* DayButton.swift in Sources */,
 				374E7B7A2B8DBF6C00BC9B26 /* TimerView.swift in Sources */,
+				371078872B8ED52F0049EB9C /* LayoutLiterals.swift in Sources */,
 				37144C662B8C32D6008565C4 /* AppDelegate.swift in Sources */,
 				376B91AA2B8C681A004CBB16 /* Pretendard.swift in Sources */,
 				37144C8E2B8C5339008565C4 /* UIView+Extension.swift in Sources */,

--- a/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
+++ b/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		370A50862B8DCBC000BD691A /* TimerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370A50852B8DCBC000BD691A /* TimerModel.swift */; };
 		37144C662B8C32D6008565C4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37144C652B8C32D6008565C4 /* AppDelegate.swift */; };
 		37144C682B8C32D6008565C4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37144C672B8C32D6008565C4 /* SceneDelegate.swift */; };
 		37144C6A2B8C32D6008565C4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37144C692B8C32D6008565C4 /* ViewController.swift */; };
@@ -29,6 +30,8 @@
 		376B91BA2B8CE6B6004CBB16 /* PobitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376B91B92B8CE6B6004CBB16 /* PobitButton.swift */; };
 		7306F5B02B8D66EE004E6055 /* NaviBar in Resources */ = {isa = PBXBuildFile; fileRef = 7306F5AF2B8D66EE004E6055 /* NaviBar */; };
 		73DFA21F2B8D8D8E00C381A7 /* UIAlertController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DFA21E2B8D8D8E00C381A7 /* UIAlertController+Extension.swift */; };
+		374E7B752B8DBECE00BC9B26 /* TimerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374E7B742B8DBECE00BC9B26 /* TimerViewController.swift */; };
+		374E7B7A2B8DBF6C00BC9B26 /* TimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374E7B792B8DBF6C00BC9B26 /* TimerView.swift */; };
 		E0C5B53E2B8D5B2700A77BAE /* DayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5B53D2B8D5B2700A77BAE /* DayButton.swift */; };
 		E0C5B5442B8D5D9A00A77BAE /* HStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5B5412B8D5D9900A77BAE /* HStackView.swift */; };
 		E0C5B5452B8D5D9A00A77BAE /* VStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5B5422B8D5D9A00A77BAE /* VStackView.swift */; };
@@ -47,6 +50,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		370A50852B8DCBC000BD691A /* TimerModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TimerModel.swift; path = PomoHabit/Presentation/Timer/Controllers/TimerModel.swift; sourceTree = SOURCE_ROOT; };
 		37144C622B8C32D6008565C4 /* PomoHabit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PomoHabit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		37144C652B8C32D6008565C4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		37144C672B8C32D6008565C4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -69,6 +73,8 @@
 		376B91B92B8CE6B6004CBB16 /* PobitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PobitButton.swift; sourceTree = "<group>"; };
 		7306F5AF2B8D66EE004E6055 /* NaviBar */ = {isa = PBXFileReference; lastKnownFileType = folder; path = NaviBar; sourceTree = "<group>"; };
 		73DFA21E2B8D8D8E00C381A7 /* UIAlertController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extension.swift"; sourceTree = "<group>"; };
+		374E7B742B8DBECE00BC9B26 /* TimerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimerViewController.swift; path = PomoHabit/Presentation/Timer/Controllers/TimerViewController.swift; sourceTree = SOURCE_ROOT; };
+		374E7B792B8DBF6C00BC9B26 /* TimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimerView.swift; path = PomoHabit/Presentation/Timer/Views/TimerView.swift; sourceTree = SOURCE_ROOT; };
 		E0C5B53D2B8D5B2700A77BAE /* DayButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayButton.swift; sourceTree = "<group>"; };
 		E0C5B5412B8D5D9900A77BAE /* HStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HStackView.swift; sourceTree = "<group>"; };
 		E0C5B5422B8D5D9A00A77BAE /* VStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VStackView.swift; sourceTree = "<group>"; };
@@ -99,6 +105,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		370A507C2B8DC8FA00BD691A /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				374E7B792B8DBF6C00BC9B26 /* TimerView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		370A50842B8DCBA400BD691A /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				370A50852B8DCBC000BD691A /* TimerModel.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		37144C592B8C32D6008565C4 = {
 			isa = PBXGroup;
 			children = (
@@ -217,9 +239,9 @@
 		37144C812B8C3434008565C4 /* Timer */ = {
 			isa = PBXGroup;
 			children = (
-				376B91972B8C5B4F004CBB16 /* Controllers */,
-				376B91982B8C5B4F004CBB16 /* Views */,
-				376B91962B8C5B4F004CBB16 /* Models */,
+				374E7B782B8DBF4A00BC9B26 /* Controllers */,
+				370A507C2B8DC8FA00BD691A /* Views */,
+				370A50842B8DCBA400BD691A /* Models */,
 			);
 			path = Timer;
 			sourceTree = "<group>";
@@ -282,6 +304,14 @@
 				37144C942B8C5472008565C4 /* BaseView.swift */,
 			);
 			path = Base;
+			sourceTree = "<group>";
+		};
+		374E7B782B8DBF4A00BC9B26 /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				374E7B742B8DBECE00BC9B26 /* TimerViewController.swift */,
+			);
+			path = Controllers;
 			sourceTree = "<group>";
 		};
 		376B91902B8C5B4C004CBB16 /* Models */ = {
@@ -348,6 +378,7 @@
 			sourceTree = "<group>";
 		};
 		376B91AD2B8C69B6004CBB16 /* Fonts */ = {
+		376B91992B8C5B51004CBB16 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
 				376B91AF2B8C6AB9004CBB16 /* Pretendard-Bold.otf */,
@@ -514,8 +545,10 @@
 				F85F8F592B8DE54F00E69922 /* Date+Extension.swift in Sources */,
 				E0C5B5452B8D5D9A00A77BAE /* VStackView.swift in Sources */,
 				F85F8F612B8E25EE00E69922 /* HabbitInfoVIew.swift in Sources */,
+				374E7B752B8DBECE00BC9B26 /* TimerViewController.swift in Sources */,
 				37144C6A2B8C32D6008565C4 /* ViewController.swift in Sources */,
 				E0C5B53E2B8D5B2700A77BAE /* DayButton.swift in Sources */,
+				374E7B7A2B8DBF6C00BC9B26 /* TimerView.swift in Sources */,
 				37144C662B8C32D6008565C4 /* AppDelegate.swift in Sources */,
 				376B91AA2B8C681A004CBB16 /* Pretendard.swift in Sources */,
 				37144C8E2B8C5339008565C4 /* UIView+Extension.swift in Sources */,
@@ -527,6 +560,7 @@
 				E0C5B5442B8D5D9A00A77BAE /* HStackView.swift in Sources */,
 				F8E3CD382B8C7FC900712CBF /* NoteView.swift in Sources */,
 				37144C682B8C32D6008565C4 /* SceneDelegate.swift in Sources */,
+				370A50862B8DCBC000BD691A /* TimerModel.swift in Sources */,
 				37144C902B8C53B0008565C4 /* UIStackView+Extension.swift in Sources */,
 				F88EB2DA2B8DC0FC0073BDDA /* WeeklyCalendarViewController.swift in Sources */,
 				F85F8F572B8DE33C00E69922 /* BasePaddingLabel.swift in Sources */,

--- a/PomoHabit/PomoHabit/Global/Base/BaseViewController.swift
+++ b/PomoHabit/PomoHabit/Global/Base/BaseViewController.swift
@@ -12,6 +12,7 @@ class BaseViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        hideNavigationBar()
         setBackgroundColor()
     }
     

--- a/PomoHabit/PomoHabit/Global/Components/NavigationBar/PobitNavigationBarView.swift
+++ b/PomoHabit/PomoHabit/Global/Components/NavigationBar/PobitNavigationBarView.swift
@@ -11,54 +11,53 @@ import SnapKit
 
 // MARK: - PobitNavigationBarView
 
-class PobitNavigationBarView: UIView {
+final class PobitNavigationBarView: UIView {
     
     // MARK: - Properties
     
     private var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.boldSystemFont(ofSize: 25)
+        label.font = Pretendard.bold(size: 25)
         
         return label
     }()
     
     private var dividerView: UIView = {
         let view = UIView()
-        view.backgroundColor = .lightGray
+        view.backgroundColor = .pobitStone3
         
         return view
     }()
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(title: String) {
+        super.init(frame: .zero)
         
         setAddSubViews()
         setAutoLayout()
+        setTitle(title)
     }
     
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }
 
 // MARK: - Layout Helpers
 
-extension NaviBarView {
+extension PobitNavigationBarView {
     private func setAddSubViews() {
-        self.addSubViews([titleLabel, dividerView])
+        addSubViews([titleLabel, dividerView])
     }
     
     private func setAutoLayout() {
-        backgroundColor = .white
-        
         titleLabel.snp.makeConstraints { make in
-            make.left.equalToSuperview().inset(20)
-            make.centerY.equalTo(self.snp.centerY)
+            make.leading.equalToSuperview().inset(LayoutLiterals.minimumHorizontalSpacing)
+            make.centerY.equalToSuperview()
         }
         
         dividerView.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(20)
-            make.width.equalTo(430)
+            make.top.equalTo(titleLabel.snp.bottom).offset(LayoutLiterals.minimumVerticalSpacing)
+            make.leading.trailing.equalToSuperview()
             make.height.equalTo(1)
         }
     }
@@ -66,7 +65,7 @@ extension NaviBarView {
 
 // MARK: - Methods
 
-extension NaviBarView {
+extension PobitNavigationBarView {
     func setTitle(_ title: String) {
         titleLabel.text = title
     }

--- a/PomoHabit/PomoHabit/Global/Components/PobitButton.swift
+++ b/PomoHabit/PomoHabit/Global/Components/PobitButton.swift
@@ -14,6 +14,7 @@ protocol PobitButtonStyle {
     var borderColor: UIColor { get }
 }
 
+/// 테두리 없는 버튼
 struct PlainButtonStyle: PobitButtonStyle {
     var backgroundColor: UIColor
     var borderColor: UIColor = .clear
@@ -55,7 +56,7 @@ final class PobitButton: UIButton {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        self.layer.cornerRadius = 15
+        self.layer.cornerRadius = 20
         self.layer.borderWidth = 1
     }
     
@@ -67,6 +68,7 @@ final class PobitButton: UIButton {
 // MARK: - Methods
 
 extension PobitButton {
+    /// 컴포지션 설정
     func setStyle(_ style: PobitButtonStyle) {
         self.style = style
     }
@@ -78,5 +80,21 @@ extension PobitButton {
     /// 런타임에 동적으로 font 업데이트 필요할 경우
     func updateFont(font: UIFont?) {
         self.buttonFont = font ?? .systemFont(ofSize: 20)
+    }
+}
+
+// MARK: - Factory Methods
+
+extension PobitButton {
+    static func makeSquareButton(title: String) -> PobitButton {
+        let button = PobitButton()
+        let style = WithBorderButtonStyle(borderColor: .pobitStone4)
+        
+        button.setStyle(style)
+        button.setTitle(title, for: .normal)
+        button.setTitleColor(.pobitBlack, for: .normal)
+        button.titleLabel?.font = Pretendard.regular(size: 20)
+        
+        return button
     }
 }

--- a/PomoHabit/PomoHabit/Global/Extensions/CAShapeLayer+Extension.swift
+++ b/PomoHabit/PomoHabit/Global/Extensions/CAShapeLayer+Extension.swift
@@ -1,0 +1,27 @@
+//
+//  CAShapeLayer+Extension.swift
+//  PomoHabit
+//
+//  Created by Joon Baek on 2024/02/28.
+//
+
+import UIKit
+
+extension CAShapeLayer {
+    // 시작점과 종료점이 설정된 원
+    static func primeCirclePath(in rect: CGRect) -> CGPath {
+        return UIBezierPath(arcCenter: CGPoint(x: rect.size.width / 2,
+                                               y: rect.size.height / 2),
+                            radius: rect.size.width * 0.4, startAngle: -.pi / 2,
+                            endAngle: 3 * .pi / 2, clockwise: true).cgPath
+    }
+    
+    static func subCirclePath(in rect: CGRect) -> CGPath {
+        return UIBezierPath(arcCenter: CGPoint(x: rect.width / 2.0,
+                                               y: rect.height / 2.0),
+                            radius: rect.size.width * 0.28,
+                            startAngle: 0.0,
+                            endAngle: .pi * 2.0,
+                            clockwise: true).cgPath
+    }
+}

--- a/PomoHabit/PomoHabit/Global/Extensions/UIViewController+Extension.swift
+++ b/PomoHabit/PomoHabit/Global/Extensions/UIViewController+Extension.swift
@@ -9,4 +9,8 @@ import UIKit
 
 extension UIViewController {
     
+    func hideNavigationBar() {
+        self.navigationController?.navigationBar.isHidden = true
+    }
+    
 }

--- a/PomoHabit/PomoHabit/Global/Literals/LayoutLiterals.swift
+++ b/PomoHabit/PomoHabit/Global/Literals/LayoutLiterals.swift
@@ -11,9 +11,9 @@ struct LayoutLiterals {
     static let minimumVerticalSpacing = 20
     static let minimumHorizontalSpacing = 20
     
-    static let upperPrimeSpacing = 24
-    static let lowerPrimeSpacing = 24
+    static let upperPrimarySpacing = 24
+    static let lowerPrimarySpacing = 24
     
-    static let upperSubprimeSpacing = 12
-    static let lowerSubprimeSpacing = 12
+    static let upperSecondarySpacing = 12
+    static let lowerSecondarySpacing = 12
 }

--- a/PomoHabit/PomoHabit/Global/Literals/LayoutLiterals.swift
+++ b/PomoHabit/PomoHabit/Global/Literals/LayoutLiterals.swift
@@ -10,4 +10,10 @@ import Foundation
 struct LayoutLiterals {
     static let minimumVerticalSpacing = 20
     static let minimumHorizontalSpacing = 20
+    
+    static let upperPrimeSpacing = 24
+    static let lowerPrimeSpacing = 24
+    
+    static let upperSubprimeSpacing = 12
+    static let lowerSubprimeSpacing = 12
 }

--- a/PomoHabit/PomoHabit/Global/Literals/LayoutLiterals.swift
+++ b/PomoHabit/PomoHabit/Global/Literals/LayoutLiterals.swift
@@ -1,0 +1,13 @@
+//
+//  LayoutLiterals.swift
+//  PomoHabit
+//
+//  Created by Joon Baek on 2024/02/28.
+//
+
+import Foundation
+
+struct LayoutLiterals {
+    static let minimumVerticalSpacing = 20
+    static let minimumHorizontalSpacing = 20
+}

--- a/PomoHabit/PomoHabit/Global/Supports/SceneDelegate.swift
+++ b/PomoHabit/PomoHabit/Global/Supports/SceneDelegate.swift
@@ -16,14 +16,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         if let windowScene = scene as? UIWindowScene {
             
+            let rootVC = TimerViewController()
+            
             let window = UIWindow(windowScene: windowScene)
             window.overrideUserInterfaceStyle = UIUserInterfaceStyle.light
-            
-            let rootVC = ViewController()
-            let navigationController = UINavigationController(rootViewController: rootVC)
-            
-            window.rootViewController = navigationController
+            window.rootViewController = rootVC
             window.makeKeyAndVisible()
+            
             self.window = window
         }
     }

--- a/PomoHabit/PomoHabit/Global/Supports/SceneDelegate.swift
+++ b/PomoHabit/PomoHabit/Global/Supports/SceneDelegate.swift
@@ -16,7 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         if let windowScene = scene as? UIWindowScene {
             
-            let rootVC = TimerViewController()
+            let rootVC = ViewController()
             
             let window = UIWindow(windowScene: windowScene)
             window.overrideUserInterfaceStyle = UIUserInterfaceStyle.light

--- a/PomoHabit/PomoHabit/Presentation/Timer/Controllers/TimerModel.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Controllers/TimerModel.swift
@@ -1,0 +1,12 @@
+//
+//  TimerModel.swift
+//  PomoHabit
+//
+//  Created by Joon Baek on 2024/02/27.
+//
+
+import Foundation
+
+struct TimerModel {
+    
+}

--- a/PomoHabit/PomoHabit/Presentation/Timer/Controllers/TimerViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Controllers/TimerViewController.swift
@@ -11,8 +11,9 @@ import UIKit
 
 final class TimerViewController: BaseViewController {
     
-    private var rootView = TimerView()
+    // MARK: - Properties
     
+    private var rootView = TimerView()
     
     // MARK: - Life Cycle
     
@@ -24,7 +25,6 @@ final class TimerViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/Timer/Controllers/TimerViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Controllers/TimerViewController.swift
@@ -1,0 +1,25 @@
+//
+//  TimerViewController.swift
+//  PomoHabit
+//
+//  Created by Joon Baek on 2024/02/27.
+//
+
+import UIKit
+
+// MARK: - TimerViewController
+
+final class TimerViewController: UIViewController {
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        
+    }
+}
+
+extension TimerViewController {
+    
+}

--- a/PomoHabit/PomoHabit/Presentation/Timer/Controllers/TimerViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Controllers/TimerViewController.swift
@@ -9,9 +9,17 @@ import UIKit
 
 // MARK: - TimerViewController
 
-final class TimerViewController: UIViewController {
+final class TimerViewController: BaseViewController {
+    
+    private var rootView = TimerView()
+    
     
     // MARK: - Life Cycle
+    
+    override func loadView() {
+        
+        view = rootView
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,5 +29,5 @@ final class TimerViewController: UIViewController {
 }
 
 extension TimerViewController {
-    
+
 }

--- a/PomoHabit/PomoHabit/Presentation/Timer/Views/CircleProgressBar.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Views/CircleProgressBar.swift
@@ -1,0 +1,113 @@
+import UIKit
+
+import SnapKit
+
+final class CircleProgressBar: UIView {
+    
+    // MARK: - UIProperties
+    
+    private lazy var progressLayer = makeLayer(strokeColor: .pobitRed, strokeEnd: 0)
+    private lazy var trackLayer = makeLayer(strokeColor: .pobitSkin, strokeEnd: 1.0)
+    private lazy var dashedCircleLayer = makeDashedCircleLayer()
+    
+    private let timeLabel: UILabel = {
+        let label = UILabel()
+        label.text = "22:01"
+        label.textColor = .pobitBlack
+        label.font = Pretendard.bold(size: 50)
+        return label
+    }()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setAddSubViews()
+        setAutoLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        configureCircularPath()
+    }
+}
+
+// MARK: - Layout Methods
+
+extension CircleProgressBar {
+    private func setAddSubViews() {
+        addSubViews([timeLabel])
+    }
+    
+    private func setAutoLayout() {
+        timeLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+    }
+    
+    private func configureCircularPath() {
+        self.layer.cornerRadius = self.frame.size.width / 2
+        
+        // 시작점과 종료점을 설정하여 원을 그림
+        let circularPath = UIBezierPath(arcCenter: CGPoint(x: frame.size.width / 2,
+                                                           y: frame.size.height / 2),
+                                        radius: frame.size.width / 2, startAngle: -.pi / 2,
+                                        endAngle: 3 * .pi / 2, clockwise: true)
+        
+        trackLayer.path = circularPath.cgPath
+        progressLayer.path = circularPath.cgPath
+        
+        [ trackLayer, progressLayer, dashedCircleLayer ].forEach { layer.addSublayer($0) }
+    }
+    
+    func setProgressWithAnimation(duration: TimeInterval, value: Float) {
+        let animation = CABasicAnimation(keyPath: "strokeEnd")
+        animation.duration = duration
+        animation.fromValue = 0
+        animation.toValue = value
+        animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.linear)
+        
+        progressLayer.strokeEnd = CGFloat(value)
+        progressLayer.add(animation, forKey: "animateprogress")
+    }
+}
+
+// MARK: - Factory Method
+
+extension CircleProgressBar {
+    private func makeLayer(strokeColor: UIColor, strokeEnd: CGFloat) -> CAShapeLayer {
+        let layer = CAShapeLayer()
+        layer.strokeColor = strokeColor.cgColor
+        layer.strokeEnd = strokeEnd
+        layer.fillColor = UIColor.clear.cgColor
+        layer.lineWidth = 40
+        layer.lineCap = .round
+        
+        return layer
+    }
+    
+    private func makeDashedCircleLayer() -> CAShapeLayer {
+        let circlePath = UIBezierPath(arcCenter: CGPoint(x: frame.size.width / 2.0,
+                                                         y: frame.size.height / 2.0),
+                                      radius: 100,
+                                      startAngle: 0.0,
+                                      endAngle: .pi * 2.0,
+                                      clockwise: true)
+        
+        let layer = CAShapeLayer()
+        layer.path = circlePath.cgPath
+        layer.strokeColor = UIColor.pobitStone4.cgColor
+        layer.fillColor = UIColor.clear.cgColor
+        layer.lineWidth = 1
+        layer.lineDashPattern = [5, 3] // [실선 길이, 공백 길이]
+        
+        return layer
+    }
+}
+

--- a/PomoHabit/PomoHabit/Presentation/Timer/Views/CircleProgressBar.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Views/CircleProgressBar.swift
@@ -4,7 +4,7 @@ import SnapKit
 
 final class CircleProgressBar: UIView {
     
-    // MARK: - UIProperties
+    // MARK: - UI Properties
     
     private lazy var progressLayer = makeLayer(strokeColor: .pobitRed, strokeEnd: 0)
     private lazy var trackLayer = makeLayer(strokeColor: .pobitSkin, strokeEnd: 1.0)
@@ -14,7 +14,8 @@ final class CircleProgressBar: UIView {
         let label = UILabel()
         label.text = "22:01"
         label.textColor = .pobitBlack
-        label.font = Pretendard.bold(size: 50)
+        label.font = Pretendard.bold(size: 44)
+        
         return label
     }()
     
@@ -54,14 +55,8 @@ extension CircleProgressBar {
     private func configureCircularPath() {
         self.layer.cornerRadius = self.frame.size.width / 2
         
-        // 시작점과 종료점을 설정하여 원을 그림
-        let circularPath = UIBezierPath(arcCenter: CGPoint(x: frame.size.width / 2,
-                                                           y: frame.size.height / 2),
-                                        radius: frame.size.width / 2, startAngle: -.pi / 2,
-                                        endAngle: 3 * .pi / 2, clockwise: true)
-        
-        trackLayer.path = circularPath.cgPath
-        progressLayer.path = circularPath.cgPath
+        trackLayer.path = CAShapeLayer.primeCirclePath(in: frame)
+        progressLayer.path = CAShapeLayer.primeCirclePath(in: frame)
         
         [ trackLayer, progressLayer, dashedCircleLayer ].forEach { layer.addSublayer($0) }
     }
@@ -93,15 +88,10 @@ extension CircleProgressBar {
     }
     
     private func makeDashedCircleLayer() -> CAShapeLayer {
-        let circlePath = UIBezierPath(arcCenter: CGPoint(x: frame.size.width / 2.0,
-                                                         y: frame.size.height / 2.0),
-                                      radius: 100,
-                                      startAngle: 0.0,
-                                      endAngle: .pi * 2.0,
-                                      clockwise: true)
+        let circlePath = CAShapeLayer.subCirclePath(in: frame)
         
         let layer = CAShapeLayer()
-        layer.path = circlePath.cgPath
+        layer.path = circlePath
         layer.strokeColor = UIColor.pobitStone4.cgColor
         layer.fillColor = UIColor.clear.cgColor
         layer.lineWidth = 1

--- a/PomoHabit/PomoHabit/Presentation/Timer/Views/CircleProgressBar.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Views/CircleProgressBar.swift
@@ -10,6 +10,8 @@ final class CircleProgressBar: UIView {
     private lazy var trackLayer = makeLayer(strokeColor: .pobitSkin, strokeEnd: 1.0)
     private lazy var dashedCircleLayer = makeDashedCircleLayer()
     
+    private let tempRedLabel = UILabel()
+    
     private let timeLabel: UILabel = {
         let label = UILabel()
         label.text = "22:01"
@@ -43,10 +45,12 @@ final class CircleProgressBar: UIView {
 
 extension CircleProgressBar {
     private func setAddSubViews() {
-        addSubViews([timeLabel])
+        addSubViews([tempRedLabel, timeLabel])
     }
     
     private func setAutoLayout() {
+        // TODO: redLabelLayout
+        
         timeLabel.snp.makeConstraints { make in
             make.center.equalToSuperview()
         }

--- a/PomoHabit/PomoHabit/Presentation/Timer/Views/TimerView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Views/TimerView.swift
@@ -11,24 +11,101 @@ import SnapKit
 
 // MARK: - TimerView
 
-final class TimerView: UIView {
+final class TimerView: BaseView {
     
     // MARK: - UI Properties
-
+    
+//    private let navigationBar: PobitNavigationBarView
+    
+    private lazy var container: HStackView = {
+        return HStackView(spacing: 16, [
+            whiteNoiseButton,
+            memoButton
+        ])
+    }()
+    
+    private lazy var whiteNoiseButton = PobitButton.makeSquareButton(title: "🎶")
+    private lazy var memoButton = PobitButton.makeSquareButton(title: "메모")
+    
+    private let habitLabel: UILabel = {
+        let label = UILabel()
+        label.text = "블라블라블라"
+        label.font = Pretendard.medium(size: 36)
+        return label
+    }()
+    
+    private let circleProgressBar = CircleProgressBar()
+    
+    private lazy var timerButton: PobitButton = {
+        let button = PobitButton()
+        let style = PlainButtonStyle(backgroundColor: .pobitStone1)
+        
+        button.setStyle(style)
+        button.setTitle("시작", for: .normal)
+        button.titleLabel?.font = Pretendard.bold(size: 20)
+        
+        return button
+    }()
+    
     // MARK: - Life Cycle
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        
+        setAddSubViews()
+        setAutoLayout()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        circleProgressBar.setProgressWithAnimation(duration: 1.0, value: 0.7)
+    }
 }
 
+// MARK: - LayoutHelpers
+
 extension TimerView {
+    private func setAddSubViews() {
+        addSubViews([container, habitLabel, circleProgressBar, timerButton])
+    }
     
+    private func setAutoLayout() {
+        container.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide)
+            make.trailing.equalToSuperview().offset(-20)
+        }
+        
+        whiteNoiseButton.snp.makeConstraints { make in
+            make.size.equalTo(58)
+        }
+        
+        memoButton.snp.makeConstraints { make in
+            make.size.equalTo(58)
+        }
+        
+        habitLabel.snp.makeConstraints { make in
+            make.top.equalTo(container.snp.bottom).offset(42)
+            make.centerX.equalToSuperview()
+        }
+        
+        circleProgressBar.snp.makeConstraints { make in
+            make.top.equalTo(habitLabel.snp.bottom).offset(48)
+            make.centerX.equalToSuperview()
+            make.leading.equalToSuperview().offset(66)
+            make.height.equalTo(self.snp.width)
+        }
+        
+        timerButton.snp.makeConstraints { make in
+            make.top.equalTo(circleProgressBar.snp.bottom).offset(60)
+            make.centerX.equalToSuperview()
+            make.width.equalTo(134)
+            make.height.equalTo(58)
+        }
+    }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/Timer/Views/TimerView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Views/TimerView.swift
@@ -1,0 +1,34 @@
+//
+//  TimerView.swift
+//  PomoHabit
+//
+//  Created by Joon Baek on 2024/02/27.
+//
+
+import UIKit
+
+import SnapKit
+
+// MARK: - TimerView
+
+final class TimerView: UIView {
+    
+    // MARK: - UI Properties
+
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension TimerView {
+    
+}
+

--- a/PomoHabit/PomoHabit/Presentation/Timer/Views/TimerView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Views/TimerView.swift
@@ -15,7 +15,7 @@ final class TimerView: BaseView {
     
     // MARK: - UI Properties
     
-//    private let navigationBar: PobitNavigationBarView
+    private let navigationBar = PobitNavigationBarView(title: "타이머")
     
     private lazy var container: HStackView = {
         return HStackView(spacing: 16, [
@@ -30,16 +30,17 @@ final class TimerView: BaseView {
     private let habitLabel: UILabel = {
         let label = UILabel()
         label.text = "블라블라블라"
-        label.font = Pretendard.medium(size: 36)
+        label.font = Pretendard.regular(size: 36)
+        
         return label
     }()
     
     private let circleProgressBar = CircleProgressBar()
     
     private lazy var timerButton: PobitButton = {
-        let button = PobitButton()
         let style = PlainButtonStyle(backgroundColor: .pobitStone1)
         
+        let button = PobitButton()
         button.setStyle(style)
         button.setTitle("시작", for: .normal)
         button.titleLabel?.font = Pretendard.bold(size: 20)
@@ -71,12 +72,18 @@ final class TimerView: BaseView {
 
 extension TimerView {
     private func setAddSubViews() {
-        addSubViews([container, habitLabel, circleProgressBar, timerButton])
+        addSubViews([navigationBar, container, habitLabel, circleProgressBar, timerButton])
     }
     
     private func setAutoLayout() {
-        container.snp.makeConstraints { make in
+        navigationBar.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(58)
+        }
+        
+        container.snp.makeConstraints { make in
+            make.top.equalTo(navigationBar.snp.bottom).offset(25)
             make.trailing.equalToSuperview().offset(-20)
         }
         
@@ -94,10 +101,9 @@ extension TimerView {
         }
         
         circleProgressBar.snp.makeConstraints { make in
-            make.top.equalTo(habitLabel.snp.bottom).offset(48)
+            make.top.equalTo(habitLabel.snp.bottom).offset(82)
             make.centerX.equalToSuperview()
-            make.leading.equalToSuperview().offset(66)
-            make.height.equalTo(self.snp.width)
+            make.size.equalTo(280)
         }
         
         timerButton.snp.makeConstraints { make in
@@ -108,4 +114,3 @@ extension TimerView {
         }
     }
 }
-


### PR DESCRIPTION
##  작업한 내용
* TimerView UI 구현
* navigationBar 파일 다시 추가
* LayoutLiterals - 미니멈 margin값 추가
* Pobit버튼 팩토리 메서드 추가

##  PR Point

리예님 빨간 버튼이랑 토마토 꼭지 이미지는 나중에 추가할게요!

### TimerView UI
* TimerViewUI 구현했습니다.
* makeSquareButton이라는 팩토리 메서드를 사용해서 공통으로 적용되는 속성들의 중복코드를 줄였습니다.

### NavigationBar
init에서 title값 받아서 바로 선언해서 사용 가능해요.
```swift
private let navigationBar = PobitNavigationBarView(title: "타이머")
```

### LayoutLiterals
레이아웃 상수화를 별로 좋아하는 편은 아닌데 최소 마진값정도는 혹시나 앞으로 변경될수도 있을 것 같아 상수화해놨습니다. 
static으로 선언되어있어 LayoutLiterals에서 .찍고 바로 사용 가능해요.

## 스크린샷

|뷰|설명|
|------|---|
|   ![image](https://github.com/PlanLit/PomoHabit/assets/97212841/b4a2b0b5-893c-4066-a89c-c823315049e8)   |  타이머뷰  |

## 관련 이슈

- Resolved: #12 