### PR TITLE
[Feat] #37 - weekly calendar view binding

### DIFF
--- a/PomoHabit/PomoHabit/Global/Extensions/Date+Extension.swift
+++ b/PomoHabit/PomoHabit/Global/Extensions/Date+Extension.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Date {
-    func monthAndDaytoString(format : String = "MM.dd") -> String {
+    func dateToString(format : String = "MM.dd") -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = format
         

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
@@ -16,16 +16,15 @@ class WeeklyCalendarViewController: BaseViewController {
     // MARK: - Properties
     
     private lazy var weeklyCalendarView = WeeklyCalendarView()
-    var weeklyDates : [Int] = []
     
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setWeeklyData()
         setAddSubViews()
         setSetAutoLayout()
-        getWeeklyData()
     }
     
     override func viewDidLayoutSubviews() { // 해당 메소드 안에서만 오토레이 아웃으로 설정된 UI/View의 Frame 사이즈를 알 수 있음
@@ -74,8 +73,9 @@ extension WeeklyCalendarViewController {
 // MARK: - Get 주간 데이터
 
 extension WeeklyCalendarViewController {
-    private func getWeeklyData(){
-        var calendar = Calendar.current
+    private func setWeeklyData(){
+        var weeklyDates : [Int] = []
+        let calendar = Calendar.current
         
         // MARK: - 현재 주의 시작 날짜
         
@@ -91,7 +91,7 @@ extension WeeklyCalendarViewController {
         
         // MARK: - 주간 데이터 구하기
         
-        guard var weeklyStartDateInt = Int(weeklyStartDate) else {return}
+        guard let weeklyStartDateInt = Int(weeklyStartDate) else {return}
         guard let currentEndDateInt = Int(currentEndDate) else {return}
         
         for i in 0...6 {
@@ -103,6 +103,8 @@ extension WeeklyCalendarViewController {
                 weeklyDates.append(date-currentEndDateInt)
             }
         }
+        
+        weeklyCalendarView.setWeeklyDates(weeklyDates: weeklyDates)
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import SnapKit
+
 // MARK: - WeeklyCalendarViewController
 
 class WeeklyCalendarViewController: BaseViewController {
@@ -14,6 +16,7 @@ class WeeklyCalendarViewController: BaseViewController {
     // MARK: - Properties
     
     private lazy var weeklyCalendarView = WeeklyCalendarView()
+    var weeklyDates : [Int] = []
     
     // MARK: - Life Cycle
     
@@ -22,6 +25,7 @@ class WeeklyCalendarViewController: BaseViewController {
         
         setAddSubViews()
         setSetAutoLayout()
+        getWeeklyData()
     }
     
     override func viewDidLayoutSubviews() { // 해당 메소드 안에서만 오토레이 아웃으로 설정된 UI/View의 Frame 사이즈를 알 수 있음
@@ -64,12 +68,42 @@ extension WeeklyCalendarViewController {
         weeklyCalendarView.setProgressCircleImg(offset: progressCircleOffset)
         weeklyCalendarView.setWeeklyHabbitProgressView(progress: progress)
     }
+    
 }
 
-// MARK: - Private Methods
+// MARK: - Get 주간 데이터
 
 extension WeeklyCalendarViewController {
-    
+    private func getWeeklyData(){
+        var calendar = Calendar.current
+        
+        // MARK: - 현재 주의 시작 날짜
+        
+        guard let result = calendar.dateInterval(of: .weekOfYear, for: Date()) else { return } // 현재 날짜가 속해있는 토요일부터 토요일까지 날짜 보여줌
+        guard let weeklyStartDate = calendar.date(byAdding: .day, value: 1, to: result.start)?.dateToString(format: "dd") else { return }
+        
+        // MARK: - 현재 주의 마지막 날짜
+        
+        let components = calendar.dateComponents([.year, .month], from: Date()) // 현재 날짜의 년도와 월
+        guard let currentStartDate = calendar.date(from: components) else { return } // 날짜와 년도를 가지고 가장 첫번째 날짜 Get
+        guard let nextStartDate = calendar.date(byAdding: .month, value: 1, to: currentStartDate) else {return} // 다음 달의 가장 첫번쨰날
+        guard let currentEndDate = calendar.date(byAdding: .day, value: -1, to: nextStartDate)?.dateToString(format: "dd") else {return} // 다음달의 가장 첫번째날 이전날 = 현재 날짜의 마지막날
+        
+        // MARK: - 주간 데이터 구하기
+        
+        guard var weeklyStartDateInt = Int(weeklyStartDate) else {return}
+        guard let currentEndDateInt = Int(currentEndDate) else {return}
+        
+        for i in 0...6 {
+            let date = weeklyStartDateInt+i
+            
+            if date <= currentEndDateInt {
+                weeklyDates.append(date)
+            }else{
+                weeklyDates.append(date-currentEndDateInt)
+            }
+        }
+    }
 }
 
 

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
@@ -42,7 +42,7 @@ final class WeeklyCalendarView: BaseView {
     
     private lazy var todayDateLabel: UILabel = {
         let label = UILabel()
-        label.text = Date().monthAndDaytoString()
+        label.text = Date().dateToString()
         label.font = Pretendard.bold(size: 50)
         label.textColor = .pobitBlack
         

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
@@ -15,9 +15,9 @@ final class WeeklyCalendarView: BaseView {
     
     // MARK: - Properties
     
-    let days = ["월","화","수","목","금","토","일"]
+    let weeklyDays = ["월","화","수","목","금","토","일"]
     
-    let dates = ["26","27","28","29","1","2","3"] // 임시
+    var weeklyDatesData : [Int] = []
     
     let habbitStates = [HabbitState.done,HabbitState.doNot,HabbitState.done,HabbitState.notStart,HabbitState.notStart,HabbitState.notStart,HabbitState.notStart] // 임시 데이터
     
@@ -241,7 +241,9 @@ extension WeeklyCalendarView {
         }
     }
     
-    
+    func setWeeklyDates(weeklyDates : [Int]){
+        weeklyDatesData = weeklyDates
+    }
 }
 
 // MARK: - Delegate
@@ -264,7 +266,7 @@ extension WeeklyCalendarView: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return days.count
+        return weeklyDatesData.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -272,8 +274,8 @@ extension WeeklyCalendarView: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         
-        cell.setDayLabelText(text: days[indexPath.item])
-        cell.setDateLabelText(text: dates[indexPath.item])
+        cell.setDayLabelText(text: weeklyDays[indexPath.item])
+        cell.setDateLabelText(text: weeklyDatesData[indexPath.item])
         cell.setCellBackgroundColor(state: habbitStates[indexPath.item])
         
         return cell

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCollectionViewCell.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCollectionViewCell.swift
@@ -92,8 +92,8 @@ extension WeeklyCollectionViewCell{
         dayLabel.text = text
     }
     
-    func setDateLabelText(text: String) { // 임시
-        dateLabel.text = text
+    func setDateLabelText(text: Int) { // 임시
+        dateLabel.text = "\(text)"
     }
     
     func setCellBackgroundColor(state: HabbitState) { //습관 정보에 따라 달라지는 cell배경및 border 함수


### PR DESCRIPTION
##  작업한 내용
주간 캘린더 - 주간 날짜 설정
##  PR Point
현재날짜기준으로 주간 날짜불러와서 설정해봤습니다. 
라이브러리 사용할려고하니깐 해당 라이브러리 캘린더뷰를 사용해야되는 이슈때문에 Foundation에 있는 Calendar와 Date이용하여 해당 기능 구현하였습니다.
## 스크린샷

|뷰|설명|
|------|---|
|  ![Simulator Screenshot - iPhone 15 Pro - 2024-03-05 at 19 28 50](https://github.com/PlanLit/PomoHabit/assets/82082770/41c61030-9c2e-4c1b-a0a0-c64da96ada80)  |  주간 캘린더 현재 날짜기준으로 일주일 날짜 설정|

## 관련 이슈

- Resolved: #37 
