### PR TITLE
[Feat] #55 CoreData설계및 데이터 바인딩

### DIFF
--- a/PomoHabit/PomoHabit/Global/CoreData/CoreDataManager.swift
+++ b/PomoHabit/PomoHabit/Global/CoreData/CoreDataManager.swift
@@ -38,6 +38,7 @@ extension CoreDataManager {
         if context.hasChanges {
             do {
                 try context.save()
+                print("성공적으로 데이터가 저장되었습니다.")
             } catch {
                 let nserror = error as NSError
                 fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
@@ -70,11 +71,34 @@ extension CoreDataManager {
         return fetchedObject
     }
     
+    private func fetchObjects<T: NSManagedObject>(for type: T.Type) throws -> [T] {
+        let entityName = String(describing: T.self)
+        let request = NSFetchRequest<T>(entityName: entityName)
+        
+        let context = persistentContainer.viewContext
+        
+        var fetchedObject : [T] = []
+        var fetchError: Error?
+        
+        context.performAndWait {
+            do {
+                let objects = try context.fetch(request)
+                fetchedObject = objects
+            } catch {
+                fetchError = error
+            }
+        }
+        
+        if let error = fetchError {
+            throw error
+        }
+        
+        return fetchedObject
+    }
     
     func fetchUser() throws -> User? {
         do {
             if let user: User = try fetchObject(for: User.self) {
-                print(user)
                 return user
             } else {
                 throw CoreDataError.fetchFailed(reason: "Failed to fetch User")
@@ -85,17 +109,21 @@ extension CoreDataManager {
         }
     }
     
-    private func updateGoalTime(for habitInfo: DailyHabitInfo) {
-        let currentGoalTimeInSeconds = habitInfo.goalTime?.timeIntervalSinceReferenceDate ?? 5 * 60
-        let updatedGoalTimeInSeconds = min(currentGoalTimeInSeconds + 60, 25 * 60)
-        habitInfo.goalTime = Date(timeIntervalSinceReferenceDate: updatedGoalTimeInSeconds)
+    func fetchDailyHabitInfos() throws -> [DailyHabitInfo] {
+        do {
+            let dailyHabitInfos : [DailyHabitInfo] = try fetchObjects(for: DailyHabitInfo.self)
+            return dailyHabitInfos
+        } catch let error {
+            print("Fetching user failed with error: \(error)")
+            throw CoreDataError.fetchFailed(reason: error.localizedDescription)
+        }
     }
 }
 
 // MARK: - Onboarding
 
 extension CoreDataManager {
-    func createUser(nickname: String, targetHabit: String, targetDate: Date, targetTime: Date) {
+    func createUser(nickname: String,targetHabit: String, targetDate: String,startTime: String,whiteNoiseType: String?) {
         
         // db에 이미 존재하는 유저가 있는지 확인
         do {
@@ -109,166 +137,39 @@ extension CoreDataManager {
         
         let context = persistentContainer.viewContext
         let user = User(context: context)
-        user.nickname = nickname
-        user.targetHabit = targetHabit
-        user.targetDate = targetDate
-        user.targetTime = targetTime
-        user.whiteNoiseType = nil
         
-        saveContext()
-        
-        // 테스트용
-        if let savedNickname = user.nickname {
-            print("Saved nickname: \(savedNickname)")
-        }
-    }
-    
-    // 습관 생성, 변경
-    func createDailyHabitInfo(user: User, targetTime: Date, hasDone: Bool, note: String) {
-        let context = persistentContainer.viewContext
-        let dailyHabitInfo = DailyHabitInfo(context: context)
-        let initialGoalTime = 5 * 60
-        
-        dailyHabitInfo.targetTime = targetTime
-        dailyHabitInfo.hasDone = hasDone
-        dailyHabitInfo.note = note
-        dailyHabitInfo.goalTime = Date(timeIntervalSinceReferenceDate: TimeInterval(initialGoalTime))
+        user.nickName = nickname // 닉네임
+        user.targetHabit = targetHabit // 습관정보
+        user.targetDate = targetDate // 습관 진행요일
+        user.startTime = startTime // 습관 진행 시간
+        user.whiteNoiseType = nil // 사운드
         
         saveContext()
     }
 }
+
 
 // MARK: - Timer
 
 extension CoreDataManager {
-    func fetchReportInfo() throws -> (habitName: String, hasDone: Bool, goalTime: Date, whiteNoiseType: String)? {
-        guard let dailyHabitInfo: DailyHabitInfo = try fetchObject(for: DailyHabitInfo.self),
-              let user: User = try fetchObject(for: User.self),
-              let habitName = user.targetHabit,
-              let whiteNoiseType = user.whiteNoiseType,
-              let goalTime = dailyHabitInfo.targetTime else {
-            throw CoreDataError.fetchFailed(reason: "Failed to fetch User in \(#function)")
-        }
-        return (habitName: habitName, hasDone: dailyHabitInfo.hasDone, goalTime: goalTime, whiteNoiseType: whiteNoiseType)
-    }
-    
-    /// 완료버튼
-    func updateDailyHabitInfo(with hasDone: Bool, note: String) throws {
-        if let dailyHabitInfo: DailyHabitInfo = try fetchObject(for: DailyHabitInfo.self) {
-            dailyHabitInfo.hasDone = hasDone
-            dailyHabitInfo.note = note
-            if hasDone {
-                updateGoalTime(for: dailyHabitInfo)
-            }
-        }
+    func createDailyHabitInfo(day: String, goalTime: Int16, hasDone: Bool, note: String) {
+        let context = persistentContainer.viewContext
+        let dailyHabitInfo = DailyHabitInfo(context: context)
+        
+        dailyHabitInfo.day = day
+        dailyHabitInfo.goalTime = goalTime
+        dailyHabitInfo.hasDone = hasDone
+        dailyHabitInfo.note = note
         
         saveContext()
-    }
-    
-    /// 화이트노이즈 변경
-    func updateWhiteNoise(with whiteNoiseType: String) throws {
-        if let user: User = try fetchObject(for: User.self) {
-            user.whiteNoiseType = whiteNoiseType
-        }
-        
-        saveContext()
-    }
-}
-
-// MARK: - Reports
-
-extension CoreDataManager {
-    
-    /// 이번달 레포트
-    func fetchCurrentMonthReportInfo() throws -> (habitName: String, hasDone: Bool, targetTime: Date, goalTime: Date)? {
-        guard let dailyHabitInfo: DailyHabitInfo = try fetchObject(for: DailyHabitInfo.self),
-              let habitName = dailyHabitInfo.habitName,
-              let targetTime = dailyHabitInfo.targetTime,
-              let goalTime = dailyHabitInfo.goalTime else {
-            throw CoreDataError.fetchFailed(reason: "Failed to fetch User in \(#function)")
-        }
-        
-        return (habitName: habitName, hasDone: dailyHabitInfo.hasDone, targetTime: targetTime, goalTime: goalTime)
-    }
-    
-    /// 습관 정보 모달
-    func fetchHabitInfo() throws -> (goalTime: Date, note: String)? {
-        guard let dailyHabitInfo: DailyHabitInfo = try fetchObject(for: DailyHabitInfo.self),
-              let goalTime = dailyHabitInfo.goalTime,
-              let note = dailyHabitInfo.note else {
-            throw CoreDataError.fetchFailed(reason: "Failed to fetch User in \(#function)")
-        }
-        return (goalTime: goalTime, note: note)
-    }
-    
-    /// 메모텍스트 변경
-    func updateMemoText(with newText: String) throws {
-        guard let dailyHabitInfo: DailyHabitInfo = try fetchObject(for: DailyHabitInfo.self) else {
-            throw CoreDataError.fetchFailed(reason: "Failed to fetch DailyHabitInfo in \(#function)")
-        }
-        
-        dailyHabitInfo.note = newText
-        saveContext()
-    }
-    
-    /// 습관 변경
-    func updateHabitTargets(habitID: UUID, targetDate: Date, targetTime: Date) throws {
-        guard let user: User = try fetchObject(for: User.self) else {
-            throw CoreDataError.fetchFailed(reason: "Failed to fetch User in \(#function)")
-        }
-        
-        user.targetDate = targetDate
-        user.targetTime = targetTime
-        saveContext()
-    }
-}
-
-// MARK: - Calendar
-
-extension CoreDataManager {
-    func fetchCalendarViewInfo() throws -> (habitName: String, hasDone: Bool, goalTime: Date, targetTime: Date)? {
-        guard let dailyHabitInfo: DailyHabitInfo = try fetchObject(for: DailyHabitInfo.self),
-              let habitName = dailyHabitInfo.habitName,
-              let goalTime = dailyHabitInfo.goalTime,
-              let targetTime = dailyHabitInfo.targetTime else {
-            throw CoreDataError.fetchFailed(reason: "Failed to fetch DailyHabitInfo in \(#function)")
-        }
-        
-        return (habitName: habitName, hasDone: dailyHabitInfo.hasDone, goalTime: goalTime, targetTime: targetTime)
-    }
-}
-
-// MARK: - Mypage
-
-extension CoreDataManager {
-    func fetchMypageViewInfo() throws -> (ongoingDays: Int, totalProgressedTime: Int)? {
-        guard let totalHabitInfo: TotalHabitInfo = try fetchObject(for: TotalHabitInfo.self) else {
-            throw CoreDataError.fetchFailed(reason: "Failed to fetch TotalHabitInfo in \(#function)")
-        }
-        
-        let ongoingDays = Int(totalHabitInfo.onGoingDaysCount)
-        let totalProgressedTime = Int(totalHabitInfo.totalProggressedTime)
-        return (ongoingDays, totalProgressedTime)
-    }
-    
-    /// 닉네임 변경
-    func updateUserNickname(to newNickname: String) {
-        guard let user = try? fetchObject(for: User.self) else { return }
-        user.nickname = newNickname
-        saveContext()
-        
-        // 테스트용
-        if let updatedNickname = user.nickname {
-            print("Updated nickname: \(updatedNickname)")
-        }
     }
 }
 
 // MARK: - Delete
 
 extension CoreDataManager {
-    func deleteAllData() {
-        let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: "User")
+    func deleteAllData(entityName: String) {
+        let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: entityName)
         let context = persistentContainer.viewContext
         
         do {
@@ -281,6 +182,16 @@ extension CoreDataManager {
             try context.save()
         } catch let error {
             print("Error deleting all data: \(error.localizedDescription)")
+        }
+    }
+}
+
+// MARK: - 파일 저장 경로
+
+extension CoreDataManager {
+    func getSaveCoredataPath(){
+        if let documentsDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last {
+            print("Documents Directory: \(documentsDirectoryURL)")
         }
     }
 }

--- a/PomoHabit/PomoHabit/Global/CoreData/CoreDataManager.swift
+++ b/PomoHabit/PomoHabit/Global/CoreData/CoreDataManager.swift
@@ -49,7 +49,6 @@ extension CoreDataManager {
     private func fetchObject<T: NSManagedObject>(for type: T.Type) throws -> T? { // User & TotalHabitInfo fetch (User와 TotalHabitInfo은 하나의 객체만 사용)
         let entityName = String(describing: T.self)
         let request = NSFetchRequest<T>(entityName: entityName)
-        
         let context = persistentContainer.viewContext
         
         var fetchedObject: T?
@@ -76,7 +75,6 @@ extension CoreDataManager {
         let request = NSFetchRequest<T>(entityName: entityName)
         
         let context = persistentContainer.viewContext
-        
         var fetchedObject : [T] = []
         var fetchError: Error?
         
@@ -111,7 +109,7 @@ extension CoreDataManager {
     
     func fetchDailyHabitInfos() throws -> [DailyHabitInfo] {
         do {
-            let dailyHabitInfos : [DailyHabitInfo] = try fetchObjects(for: DailyHabitInfo.self)
+            let dailyHabitInfos: [DailyHabitInfo] = try fetchObjects(for: DailyHabitInfo.self)
             
             return dailyHabitInfos
         } catch let error {
@@ -124,7 +122,7 @@ extension CoreDataManager {
 // MARK: - Onboarding
 
 extension CoreDataManager {
-    func createUser(nickname: String,targetHabit: String, targetDate: String,startTime: String,whiteNoiseType: String?) { // User 엔티티 저장
+    func createUser(nickname: String, targetHabit: String, targetDate: String, startTime: String, whiteNoiseType: String?) { // User 엔티티 저장
         // db에 이미 존재하는 유저가 있는지 확인
         do {
             if let _ = try fetchUser() {
@@ -138,7 +136,7 @@ extension CoreDataManager {
         let context = persistentContainer.viewContext
         let user = User(context: context)
         
-        user.nickName = nickname // 닉네임
+        user.nickname = nickname // 닉네임
         user.targetHabit = targetHabit // 습관정보
         user.targetDate = targetDate // 습관 진행요일
         user.startTime = startTime // 습관 진행 시간

--- a/PomoHabit/PomoHabit/Global/CoreData/CoreDataManager.swift
+++ b/PomoHabit/PomoHabit/Global/CoreData/CoreDataManager.swift
@@ -46,7 +46,7 @@ extension CoreDataManager {
         }
     }
     
-    private func fetchObject<T: NSManagedObject>(for type: T.Type) throws -> T? {
+    private func fetchObject<T: NSManagedObject>(for type: T.Type) throws -> T? { // User & TotalHabitInfo fetch (User와 TotalHabitInfo은 하나의 객체만 사용)
         let entityName = String(describing: T.self)
         let request = NSFetchRequest<T>(entityName: entityName)
         
@@ -71,7 +71,7 @@ extension CoreDataManager {
         return fetchedObject
     }
     
-    private func fetchObjects<T: NSManagedObject>(for type: T.Type) throws -> [T] {
+    private func fetchObjects<T: NSManagedObject>(for type: T.Type) throws -> [T] { // DailyHabiInfo fetch (DailyHabiInfo는 여러개의 객체 사용)
         let entityName = String(describing: T.self)
         let request = NSFetchRequest<T>(entityName: entityName)
         
@@ -96,7 +96,7 @@ extension CoreDataManager {
         return fetchedObject
     }
     
-    func fetchUser() throws -> User? {
+    func fetchUser() throws -> User? { // CordData에서 User데이터 Read
         do {
             if let user: User = try fetchObject(for: User.self) {
                 return user
@@ -112,6 +112,7 @@ extension CoreDataManager {
     func fetchDailyHabitInfos() throws -> [DailyHabitInfo] {
         do {
             let dailyHabitInfos : [DailyHabitInfo] = try fetchObjects(for: DailyHabitInfo.self)
+            
             return dailyHabitInfos
         } catch let error {
             print("Fetching user failed with error: \(error)")
@@ -123,8 +124,7 @@ extension CoreDataManager {
 // MARK: - Onboarding
 
 extension CoreDataManager {
-    func createUser(nickname: String,targetHabit: String, targetDate: String,startTime: String,whiteNoiseType: String?) {
-        
+    func createUser(nickname: String,targetHabit: String, targetDate: String,startTime: String,whiteNoiseType: String?) { // User 엔티티 저장
         // db에 이미 존재하는 유저가 있는지 확인
         do {
             if let _ = try fetchUser() {
@@ -152,20 +152,20 @@ extension CoreDataManager {
 // MARK: - Timer
 
 extension CoreDataManager {
-    func createDailyHabitInfo(day: String, goalTime: Int16, hasDone: Bool, note: String) {
+    func createDailyHabitInfo(day: String, goalTime: Int16, hasDone: Bool, note: String) { // DailyHabitInfo 엔티티 저장
         let context = persistentContainer.viewContext
         let dailyHabitInfo = DailyHabitInfo(context: context)
         
-        dailyHabitInfo.day = day
-        dailyHabitInfo.goalTime = goalTime
-        dailyHabitInfo.hasDone = hasDone
-        dailyHabitInfo.note = note
+        dailyHabitInfo.day = day // 날짜
+        dailyHabitInfo.goalTime = goalTime // 목표 시간
+        dailyHabitInfo.hasDone = hasDone // 완료여부
+        dailyHabitInfo.note = note // 메모
         
         saveContext()
     }
 }
 
-// MARK: - Delete
+// MARK: - 해당 엔티티 All Delete
 
 extension CoreDataManager {
     func deleteAllData(entityName: String) {
@@ -186,7 +186,7 @@ extension CoreDataManager {
     }
 }
 
-// MARK: - 파일 저장 경로
+// MARK: - CoreData 파일 저장 경로 얻는 함수
 
 extension CoreDataManager {
     func getSaveCoredataPath(){

--- a/PomoHabit/PomoHabit/Global/CoreData/CoreDataManager.swift
+++ b/PomoHabit/PomoHabit/Global/CoreData/CoreDataManager.swift
@@ -50,7 +50,6 @@ extension CoreDataManager {
         let entityName = String(describing: T.self)
         let request = NSFetchRequest<T>(entityName: entityName)
         let context = persistentContainer.viewContext
-        
         var fetchedObject: T?
         var fetchError: Error?
         
@@ -73,7 +72,6 @@ extension CoreDataManager {
     private func fetchObjects<T: NSManagedObject>(for type: T.Type) throws -> [T] { // DailyHabiInfo fetch (DailyHabiInfo는 여러개의 객체 사용)
         let entityName = String(describing: T.self)
         let request = NSFetchRequest<T>(entityName: entityName)
-        
         let context = persistentContainer.viewContext
         var fetchedObject : [T] = []
         var fetchError: Error?

--- a/PomoHabit/PomoHabit/Global/CoreData/PobitModel.xcdatamodeld/PobitModel.xcdatamodel/contents
+++ b/PomoHabit/PomoHabit/Global/CoreData/PobitModel.xcdatamodeld/PobitModel.xcdatamodel/contents
@@ -1,29 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="22G436" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="23D56" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="DailyHabitInfo" representedClassName="DailyHabitInfo" syncable="YES" codeGenerationType="class">
-        <attribute name="day" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="goalTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="habitID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="habitName" optional="YES" attributeType="String"/>
+        <attribute name="day" optional="YES" attributeType="String"/>
+        <attribute name="goalTime" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="hasDone" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="note" optional="YES" attributeType="String"/>
-        <attribute name="targetTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <relationship name="relationship" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User"/>
     </entity>
     <entity name="TotalHabitInfo" representedClassName="TotalHabitInfo" syncable="YES" codeGenerationType="class">
         <attribute name="habitCompletedCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="habitCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="onGoingDaysCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="totalProggressedTime" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <relationship name="relationship" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User"/>
     </entity>
     <entity name="User" representedClassName="User" syncable="YES" codeGenerationType="class">
-        <attribute name="nickname" optional="YES" attributeType="String"/>
-        <attribute name="targetDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="nickName" optional="YES" attributeType="String"/>
+        <attribute name="startTime" optional="YES" attributeType="String"/>
+        <attribute name="targetDate" optional="YES" attributeType="String"/>
         <attribute name="targetHabit" optional="YES" attributeType="String"/>
-        <attribute name="targetTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="whiteNoiseType" optional="YES" attributeType="String"/>
-        <relationship name="relationship" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TotalHabitInfo"/>
-        <relationship name="relationship1" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DailyHabitInfo"/>
     </entity>
 </model>

--- a/PomoHabit/PomoHabit/Global/CoreData/PobitModel.xcdatamodeld/PobitModel.xcdatamodel/contents
+++ b/PomoHabit/PomoHabit/Global/CoreData/PobitModel.xcdatamodeld/PobitModel.xcdatamodel/contents
@@ -6,14 +6,8 @@
         <attribute name="hasDone" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="note" optional="YES" attributeType="String"/>
     </entity>
-    <entity name="TotalHabitInfo" representedClassName="TotalHabitInfo" syncable="YES" codeGenerationType="class">
-        <attribute name="habitCompletedCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="habitCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="onGoingDaysCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="totalProggressedTime" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-    </entity>
     <entity name="User" representedClassName="User" syncable="YES" codeGenerationType="class">
-        <attribute name="nickName" optional="YES" attributeType="String"/>
+        <attribute name="nickname" optional="YES" attributeType="String"/>
         <attribute name="startTime" optional="YES" attributeType="String"/>
         <attribute name="targetDate" optional="YES" attributeType="String"/>
         <attribute name="targetHabit" optional="YES" attributeType="String"/>

--- a/PomoHabit/PomoHabit/Presentation/Mypage/Controllers/MypageViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Mypage/Controllers/MypageViewController.swift
@@ -30,3 +30,19 @@ final class MyPageViewController: UIViewController, BottomSheetPresentable {
         
     }
 }
+
+// MARK: - Data 전처리
+
+extension MyPageViewController {
+    private func setTotalHabitInfo() {
+        do {
+            let dailyHabitInfos = try CoreDataManager.shared.fetchDailyHabitInfos() // 전체 DailyHabit 데이터
+            let totalHabitDoneCount = dailyHabitInfos.filter{ $0.hasDone == true }.count // 습관 진행 일수
+            let totlaHabitDuringTime = dailyHabitInfos.filter{ $0.hasDone == true }.map{$0.goalTime}.reduce(0, +) // 진행 총 시간 , 분단위
+            // 완료한 습관 수를 어떻게 할것인지 상의 필요할것 같습니다.
+            
+        } catch {
+            
+        }
+    }
+}

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingChattingViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingChattingViewController.swift
@@ -45,7 +45,7 @@ final class OnboardingChattingViewController: UIViewController {
         
         setAddSubviews()
         setAutoLayout()
-        didtapNextButton()
+//        didtapNextButton() // 임시로 만들어 놓은 함수입니다. 다음버튼 action연결해서 해당 함수 안에 있는 코드 사용하시면 됩니다.
     }
 }
 
@@ -115,6 +115,6 @@ extension OnboardingChattingViewController: UICollectionViewDelegateFlowLayout {
 extension OnboardingChattingViewController {
     func didtapNextButton() {
         // user 데이터 설정
-        CoreDataManager.shared.createUser(nickname: "동진", targetHabit: "독서", targetDate: "월,화,수,목,금", startTime: "09 00 AM", whiteNoiseType: nil)
+        CoreDataManager.shared.createUser(nickname: "동진", targetHabit: "독서", targetDate: "월,화,수,목,금", startTime: "09 : 00 AM", whiteNoiseType: nil)
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingChattingViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingChattingViewController.swift
@@ -45,6 +45,7 @@ final class OnboardingChattingViewController: UIViewController {
         
         setAddSubviews()
         setAutoLayout()
+        didtapNextButton()
     }
 }
 
@@ -108,5 +109,12 @@ extension OnboardingChattingViewController: UICollectionViewDelegateFlowLayout {
         } else {
             return CGSize(width: collectionView.frame.width, height: 50)
         }
+    }
+}
+
+extension OnboardingChattingViewController {
+    func didtapNextButton() {
+        // user 데이터 설정
+        CoreDataManager.shared.createUser(nickname: "동진", targetHabit: "독서", targetDate: "월,화,수,목,금", startTime: "09 00 AM", whiteNoiseType: nil)
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingFirstViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingFirstViewController.swift
@@ -85,18 +85,6 @@ extension OnboardingFirstViewController {
 
 extension OnboardingFirstViewController {
     @objc private func didTapSubmitButton() {
-        guard let nickname = nicknameTextField.text else { return }
-
-              // 임시값
-              let targetHabit = "Running"
-              let targetDate = Date()
-              let targetTime = Date()
-
-              CoreDataManager.shared.createUser(nickname: nickname, targetHabit: targetHabit, targetDate: targetDate, targetTime: targetTime)
-        
-        // 닉네임 변경 테스트
-        CoreDataManager.shared.updateUserNickname(to: "변경된 닉네임")
-        
         let onboardingChattingViewController = OnboardingChattingViewController()
         self.navigationController?.pushViewController(onboardingChattingViewController, animated: true)
     }

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -323,7 +323,7 @@ extension ReportViewController {
     func getSelectedDayHabitInfo(selectedDay: String) { // selectedDay 매개변수를 통해 해당하는 날짜의 습관정보를 불러옴, 날짜 형식 2024-03-08
         do {
             let habitInfos = try CoreDataManager.shared.fetchDailyHabitInfos()
-            let habitInfoDays = habitInfos.map{$0.day!} // map할때 옵셔널 푸는방법 아시는 분 있으시면 피드백 부탁드립니다. 임시로 강제 해제로 했습니다.
+            let habitInfoDays = habitInfos.compactMap{$0.day}
             
             if let index = habitInfoDays.firstIndex(where: {$0 == selectedDay}) {
                 let selectedHabitInfo = habitInfos[index]
@@ -340,7 +340,7 @@ extension ReportViewController {
     func getUserData() {
         do {
             let userData = try CoreDataManager.shared.fetchUser()
-            guard let nickName = userData?.nickName else { return } // 닉네임
+            guard let nickname = userData?.nickname else { return } // 닉네임
             guard let targetHabit = userData?.targetHabit else { return } // 할 습관
             guard let targetDate = userData?.targetDate else { return } // 습관을 진행할 요일
             guard let startTime = userData?.startTime else { return } // 습관 진행 시간

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -37,6 +37,8 @@ final class ReportViewController: BaseViewController, BottomSheetPresentable {
         
         setAddSubviews()
         setAutoLayout()
+//        getMonthHabitCompletedInfo()
+        getSelectedDayHabitInfo(selectedDay: "2024-03-07")
     }
 }
 
@@ -305,5 +307,47 @@ extension ReportViewController {
 extension ReportViewController {
     enum Check {
         case complete, fail, rest
+    }
+}
+
+extension ReportViewController {
+    func getMonthHabitCompletedInfo() {
+        do {
+            let monthHabitCompletedInfo = try CoreDataManager.shared.fetchDailyHabitInfos().map{$0.hasDone} // 한달 동안의 습관 완료 기록, 습관을 시작하는날이 아닌경우에는 표시안됨
+            print(monthHabitCompletedInfo)
+        }catch {
+            print(error)
+        }
+    }
+    
+    func getSelectedDayHabitInfo(selectedDay : String) {
+        do {
+            let habitInfos = try CoreDataManager.shared.fetchDailyHabitInfos()
+            let habitInfoDays = habitInfos.map{$0.day!}
+            if let index = habitInfoDays.firstIndex(where: {$0 == selectedDay}) {
+                let selectedHabitInfo = habitInfos[index]
+                guard let day = selectedHabitInfo.day else { return }
+                let goalTime = selectedHabitInfo.goalTime
+                let hasDone = selectedHabitInfo.hasDone
+                guard let note = selectedHabitInfo.note else { return }
+                
+            }
+            
+        }catch {
+            print(error)
+        }
+    }
+    func getUserData() {
+        do {
+            let userData = try CoreDataManager.shared.fetchUser()
+            guard let nickName = userData?.nickName else { return } // 닉네임
+            guard let targetHabit = userData?.targetHabit else { return } // 할 습관
+            guard let targetDate = userData?.targetDate else { return } // 습관을 진행할 요일
+            guard let startTime = userData?.startTime else { return } // 습관 진행 시간
+            guard let whiteNoiseType = userData?.whiteNoiseType else { return } // 사운드
+            
+        } catch {
+            print(error)
+        }
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -37,8 +37,8 @@ final class ReportViewController: BaseViewController, BottomSheetPresentable {
         
         setAddSubviews()
         setAutoLayout()
-//        getMonthHabitCompletedInfo()
-        getSelectedDayHabitInfo(selectedDay: "2024-03-07")
+//        getMonthHabitCompletedInfo() // 한달 동안의 습관 완료 여부 마찬가지로 임시로 만들어 둔것입니다. 안에 있는 로직 활용하시면 됩니다.
+//        getSelectedDayHabitInfo(selectedDay: "2024-03-07")
     }
 }
 
@@ -314,29 +314,29 @@ extension ReportViewController {
     func getMonthHabitCompletedInfo() {
         do {
             let monthHabitCompletedInfo = try CoreDataManager.shared.fetchDailyHabitInfos().map{$0.hasDone} // 한달 동안의 습관 완료 기록, 습관을 시작하는날이 아닌경우에는 표시안됨
-            print(monthHabitCompletedInfo)
-        }catch {
+            print(monthHabitCompletedInfo) // 테스트후 지우셔도 됩니다.
+        } catch {
             print(error)
         }
     }
     
-    func getSelectedDayHabitInfo(selectedDay : String) {
+    func getSelectedDayHabitInfo(selectedDay: String) { // selectedDay 매개변수를 통해 해당하는 날짜의 습관정보를 불러옴, 날짜 형식 2024-03-08
         do {
             let habitInfos = try CoreDataManager.shared.fetchDailyHabitInfos()
-            let habitInfoDays = habitInfos.map{$0.day!}
+            let habitInfoDays = habitInfos.map{$0.day!} // map할때 옵셔널 푸는방법 아시는 분 있으시면 피드백 부탁드립니다. 임시로 강제 해제로 했습니다.
+            
             if let index = habitInfoDays.firstIndex(where: {$0 == selectedDay}) {
                 let selectedHabitInfo = habitInfos[index]
                 guard let day = selectedHabitInfo.day else { return }
                 let goalTime = selectedHabitInfo.goalTime
                 let hasDone = selectedHabitInfo.hasDone
                 guard let note = selectedHabitInfo.note else { return }
-                
             }
-            
-        }catch {
+        } catch {
             print(error)
         }
     }
+    
     func getUserData() {
         do {
             let userData = try CoreDataManager.shared.fetchUser()
@@ -345,7 +345,6 @@ extension ReportViewController {
             guard let targetDate = userData?.targetDate else { return } // 습관을 진행할 요일
             guard let startTime = userData?.startTime else { return } // 습관 진행 시간
             guard let whiteNoiseType = userData?.whiteNoiseType else { return } // 사운드
-            
         } catch {
             print(error)
         }

--- a/PomoHabit/PomoHabit/Presentation/Timer/ViewControllers/PomoViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/ViewControllers/PomoViewController.swift
@@ -24,10 +24,28 @@ final class TimerViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
     }
 }
 
 extension TimerViewController {
+    func getUserData() {
+        do {
+            let userData = try CoreDataManager.shared.fetchUser()
+            guard let nickName = userData?.nickName else { return } // 닉네임
+            guard let targetHabit = userData?.targetHabit else { return } // 할 습관
+            guard let targetDate = userData?.targetDate else { return } // 습관을 진행할 요일
+            guard let startTime = userData?.startTime else { return } // 습관 진행 시간
+            guard let whiteNoiseType = userData?.whiteNoiseType else { return } // 사운드
+            
+        } catch {
+            print(error)
+        }
+    }
+    
+    func completedTodayHabit() {
+        let date = Date().dateToString(format: "yyyy-MM-dd")
 
+        CoreDataManager.shared.createDailyHabitInfo(day: date, goalTime: 7, hasDone: true, note: "3번째 날입니다.")
+    }
 }

--- a/PomoHabit/PomoHabit/Presentation/Timer/ViewControllers/PomoViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/ViewControllers/PomoViewController.swift
@@ -37,15 +37,15 @@ extension TimerViewController {
             guard let targetDate = userData?.targetDate else { return } // 습관을 진행할 요일
             guard let startTime = userData?.startTime else { return } // 습관 진행 시간
             guard let whiteNoiseType = userData?.whiteNoiseType else { return } // 사운드
-            
         } catch {
             print(error)
         }
     }
     
-    func completedTodayHabit() {
+    func completedTodayHabit() { // 타이머 완료시 실행되는 함수입니다. 아래에 코드를 활용하시면 됩니다.
         let date = Date().dateToString(format: "yyyy-MM-dd")
-
+        let chnageDate = Calendar.current.date(byAdding: .day,value: 1,to: date)?.dateToString(format: "yyyy-MM-dd") // 오늘 날짜 기준으로 +,- 할수 있 습니다 .테스트할때 사용하시고 지워 주시면 됩니다.
+        
         CoreDataManager.shared.createDailyHabitInfo(day: date, goalTime: 7, hasDone: true, note: "3번째 날입니다.")
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Timer/ViewControllers/PomoViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/ViewControllers/PomoViewController.swift
@@ -32,7 +32,7 @@ extension TimerViewController {
     func getUserData() {
         do {
             let userData = try CoreDataManager.shared.fetchUser()
-            guard let nickName = userData?.nickName else { return } // 닉네임
+            guard let nickName = userData?.nickname else { return } // 닉네임
             guard let targetHabit = userData?.targetHabit else { return } // 할 습관
             guard let targetDate = userData?.targetDate else { return } // 습관을 진행할 요일
             guard let startTime = userData?.startTime else { return } // 습관 진행 시간
@@ -43,8 +43,9 @@ extension TimerViewController {
     }
     
     func completedTodayHabit() { // 타이머 완료시 실행되는 함수입니다. 아래에 코드를 활용하시면 됩니다.
+        let currentDate = Date() // 테스트할때 사용하시고 지워주시면 됩니다.
         let date = Date().dateToString(format: "yyyy-MM-dd")
-        let chnageDate = Calendar.current.date(byAdding: .day,value: 1,to: date)?.dateToString(format: "yyyy-MM-dd") // 오늘 날짜 기준으로 +,- 할수 있 습니다 .테스트할때 사용하시고 지워 주시면 됩니다.
+        let changeDate = Calendar.current.date(byAdding: .day,value: 1, to: currentDate)?.dateToString(format: "yyyy-MM-dd") // 오늘 날짜 기준으로 +,- 할수 있 습니다 .테스트할때 사용하시고 지워 주시면 됩니다.
         
         CoreDataManager.shared.createDailyHabitInfo(day: date, goalTime: 7, hasDone: true, note: "3번째 날입니다.")
     }

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
@@ -109,7 +109,7 @@ extension WeeklyCalendarViewController {
     func getSelectedDayHabitInfo(selectedDay: String) {
         do {
             let habitInfos = try CoreDataManager.shared.fetchDailyHabitInfos()
-            let habitInfoDays = habitInfos.map{$0.day!} // 마찬가지로 매핑할떄 강제 옵셔널해제 말고 옵셔널 해제 하는 방법 아시는분 피드백 부탁드립니다!
+            let habitInfoDays = habitInfos.compactMap{$0.day}
             
             if let index = habitInfoDays.firstIndex(where: {$0 == selectedDay}) {
                 let selectedHabitInfo = habitInfos[index]

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
@@ -105,6 +105,23 @@ extension WeeklyCalendarViewController {
         
         weeklyCalendarView.setWeeklyDates(weeklyDates: weeklyDates)
     }
+    
+    func getSelectedDayHabitInfo(selectedDay : String) {
+        do {
+            let habitInfos = try CoreDataManager.shared.fetchDailyHabitInfos()
+            let habitInfoDays = habitInfos.map{$0.day!}
+            if let index = habitInfoDays.firstIndex(where: {$0 == selectedDay}) {
+                let selectedHabitInfo = habitInfos[index]
+                guard let day = selectedHabitInfo.day else { return }
+                let goalTime = selectedHabitInfo.goalTime
+                let hasDone = selectedHabitInfo.hasDone
+                guard let note = selectedHabitInfo.note else { return }
+                print("day :\(day),goalTime:\(goalTime),hasDone:\(hasDone),note:\(note)")
+            }
+        }catch {
+            print(error)
+        }
+    }
 }
 
 

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
@@ -106,17 +106,19 @@ extension WeeklyCalendarViewController {
         weeklyCalendarView.setWeeklyDates(weeklyDates: weeklyDates)
     }
     
-    func getSelectedDayHabitInfo(selectedDay : String) {
+    func getSelectedDayHabitInfo(selectedDay: String) {
         do {
             let habitInfos = try CoreDataManager.shared.fetchDailyHabitInfos()
-            let habitInfoDays = habitInfos.map{$0.day!}
+            let habitInfoDays = habitInfos.map{$0.day!} // 마찬가지로 매핑할떄 강제 옵셔널해제 말고 옵셔널 해제 하는 방법 아시는분 피드백 부탁드립니다!
+            
             if let index = habitInfoDays.firstIndex(where: {$0 == selectedDay}) {
                 let selectedHabitInfo = habitInfos[index]
                 guard let day = selectedHabitInfo.day else { return }
                 let goalTime = selectedHabitInfo.goalTime
                 let hasDone = selectedHabitInfo.hasDone
                 guard let note = selectedHabitInfo.note else { return }
-                print("day :\(day),goalTime:\(goalTime),hasDone:\(hasDone),note:\(note)")
+                
+                print("day :\(day),goalTime:\(goalTime),hasDone:\(hasDone),note:\(note)") // 데이터 확인을 위하여 임시로 적어 두었습니다.
             }
         }catch {
             print(error)


### PR DESCRIPTION
##  작업한 내용
CoreData 설계 및 데이터 바인딩

##  PR Point
각 뷰컨에 필요한 데이터 불러오고 데이터 생성하게 만들었습니다.
전체 습관에 대한 데이터 관리 엔티티 없애고 DailyHabitInfo 데이터로 전처리하는 방식으로 구현해봤습니다.
https://github.com/PlanLit/PomoHabit/pull/56/commits/79924e410d6a725bac27a9b72e4b90c26a8898d4

### 함수
`fetchUser()` 함수 : CordData에서 User데이터 Read
`fetchDailyHabitInfos()`함수 : CoreData에서 DailyHabitInfos데이터 	Read
`createUser() `함수 : 온보딩에서 입력된 정보를 가지고 User 엔티티에 저장d
`createDailyHabitInfo()` 함수 : 타이머에서 습관 완료시 해당 사항을  DailyHabitInfo 엔티티에 저장
`deleteAllData()` 함수 :  엔티티 All Delete
`getSaveCoredataPath()`함수 : CoreData 파일 저장 경로 얻는 함수

뷰바인딩을 위한 함수는 해당 함수 옆에 주석 적어놓았습니다 .
이름이나 안에 있는 로직 활용하여 뷰바인딩및 데이터 생성 진행하시면됩니다.

### 저장 규칙
day 저장 규칙
날짜 저장방식 년도-월-일
Ex 2024-03-08

targetDate 저장 규칙
요일 사이에 ","를 활용하여 구분
Ex 월,화,수,목,금

startTime 저장 규칙
공백활용 
이유 :뷰에 보여질때 String을 다시 바꾸지 않기 위함
Ex 09 : 00 AM

위에 저장 규칙 중 이상하거나 더 좋은 의견이 있으면 피드백 부탁드립니다.

제가 적은 코드중 이해가 안되시거나 활용법을 모르겠다 하시면 DM주세요



## 관련 이슈

- Resolved: #55
