### PR TITLE
[Feat] #59 - 온보딩 데이터 바인딩, 리포트는 일부만 바인딩

### DIFF
--- a/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
+++ b/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
@@ -527,8 +527,8 @@
 		F8A4FB902B96F2A300E46EA1 /* HabitInfo */ = {
 			isa = PBXGroup;
 			children = (
-				F8A4FB912B96F2A300E46EA1 /* ReportDayButtonTableViewCell.swift */,
 				F8A4FB922B96F2A300E46EA1 /* ReportHabitInfoView.swift */,
+				F8A4FB912B96F2A300E46EA1 /* ReportDayButtonTableViewCell.swift */,
 			);
 			path = HabitInfo;
 			sourceTree = "<group>";

--- a/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
+++ b/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
@@ -73,7 +73,7 @@
 		F8A4FB962B96F2A300E46EA1 /* ReportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A4FB8E2B96F2A300E46EA1 /* ReportViewController.swift */; };
 		F8A4FB972B96F2A300E46EA1 /* ReportDayButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A4FB912B96F2A300E46EA1 /* ReportDayButtonTableViewCell.swift */; };
 		F8A4FB982B96F2A300E46EA1 /* ReportHabitInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A4FB922B96F2A300E46EA1 /* ReportHabitInfoView.swift */; };
-		F8A4FB992B96F2A300E46EA1 /* ReportHabitEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A4FB942B96F2A300E46EA1 /* ReportHabitEditView.swift */; };
+		F8A4FB992B96F2A300E46EA1 /* ReportHabitDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A4FB942B96F2A300E46EA1 /* ReportHabitDetailView.swift */; };
 		F8E3CD382B8C7FC900712CBF /* NoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E3CD372B8C7FC900712CBF /* NoteView.swift */; };
 		F8E3CD3A2B8C7FF200712CBF /* NoteTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E3CD392B8C7FF200712CBF /* NoteTextView.swift */; };
 /* End PBXBuildFile section */
@@ -145,7 +145,7 @@
 		F8A4FB8E2B96F2A300E46EA1 /* ReportViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReportViewController.swift; sourceTree = "<group>"; };
 		F8A4FB912B96F2A300E46EA1 /* ReportDayButtonTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReportDayButtonTableViewCell.swift; sourceTree = "<group>"; };
 		F8A4FB922B96F2A300E46EA1 /* ReportHabitInfoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReportHabitInfoView.swift; sourceTree = "<group>"; };
-		F8A4FB942B96F2A300E46EA1 /* ReportHabitEditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReportHabitEditView.swift; sourceTree = "<group>"; };
+		F8A4FB942B96F2A300E46EA1 /* ReportHabitDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReportHabitDetailView.swift; sourceTree = "<group>"; };
 		F8E3CD372B8C7FC900712CBF /* NoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteView.swift; sourceTree = "<group>"; };
 		F8E3CD392B8C7FF200712CBF /* NoteTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteTextView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -536,7 +536,7 @@
 		F8A4FB932B96F2A300E46EA1 /* HabitEdit */ = {
 			isa = PBXGroup;
 			children = (
-				F8A4FB942B96F2A300E46EA1 /* ReportHabitEditView.swift */,
+				F8A4FB942B96F2A300E46EA1 /* ReportHabitDetailView.swift */,
 			);
 			path = HabitEdit;
 			sourceTree = "<group>";
@@ -632,7 +632,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F88EB2D82B8DC0EB0073BDDA /* WeeklyCalendarModel.swift in Sources */,
-				F8A4FB992B96F2A300E46EA1 /* ReportHabitEditView.swift in Sources */,
+				F8A4FB992B96F2A300E46EA1 /* ReportHabitDetailView.swift in Sources */,
 				BAFEE1542B96F900009F0D25 /* MypageTableViewCell.swift in Sources */,
 				378034AD2B8FAB5B0046E6B8 /* WhiteNoiseView.swift in Sources */,
 				F8E3CD3A2B8C7FF200712CBF /* NoteTextView.swift in Sources */,

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
@@ -11,6 +11,10 @@ import UIKit
 
 final class OnboardingLoginViewController: UIViewController {
     
+    // MARK: - Data Properties
+    
+    var nickName: String?
+    
     // MARK: - Properties
     
     private lazy var container: VStackView = makeContainer()
@@ -25,7 +29,6 @@ final class OnboardingLoginViewController: UIViewController {
 
         setAddSubviews()
         setAutoLayout()
-//        didtapNextButton() // 임시로 만들어 놓은 함수입니다. 다음버튼 action연결해서 해당 함수 안에 있는 코드 사용하시면 됩니다.
     }
 }
 
@@ -88,8 +91,9 @@ extension OnboardingLoginViewController {
     
     private func makeNextButton() -> UIButton {
         let button = UIButton(type: .custom, primaryAction: .init(handler: { _ in
-            let onboardingChattingViewController = OnboardingHabitRegisterViewController()
-            self.navigationController?.pushViewController(onboardingChattingViewController, animated: true)
+            let onboardingHabitRegisterViewController = OnboardingHabitRegisterViewController()
+            onboardingHabitRegisterViewController.nickName = self.nickName
+            self.navigationController?.pushViewController(onboardingHabitRegisterViewController, animated: true)
         }))
         button.setImage(UIImage(named: "arrow"), for: .normal)
         button.layer.opacity = 0.5
@@ -107,7 +111,7 @@ extension OnboardingLoginViewController {
 
 extension OnboardingLoginViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        print("textFieldDidChangeSelection")
+        nickName = textField.text
         if textField.text != "" {
             nextButton.layer.opacity = 1
             nextButton.isUserInteractionEnabled = true
@@ -120,14 +124,5 @@ extension OnboardingLoginViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
-    }
-}
-
-// MARK: - CoreData
-
-extension OnboardingLoginViewController {
-    func didtapNextButton() {
-        // user 데이터 설정
-        CoreDataManager.shared.createUser(nickname: "동진", targetHabit: "독서", targetDate: "월,화,수,목,금", startTime: "09 : 00 AM", whiteNoiseType: nil)
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
@@ -15,7 +15,7 @@ final class OnboardingLoginViewController: UIViewController {
     
     var nickName: String?
     
-    // MARK: - Properties
+    // MARK: - UI Properties
     
     private lazy var container: VStackView = makeContainer()
     private lazy var nextButton: UIButton = makeNextButton()

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingChattingTableViewCell.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingChattingTableViewCell.swift
@@ -14,7 +14,6 @@ final class OnboardingChattingTableViewCell: UITableViewCell {
     // MARK: - Properties
     
     private var data: OnboardingChattingCellData?
-    
     private lazy var chattingLabel: BasePaddingLabel = makeChattingLabel()
     
     // MARK: - Life Cycles

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingDatePickerTableViewCell.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingDatePickerTableViewCell.swift
@@ -13,7 +13,7 @@ final class OnboardingDatePickerTableViewCell: UITableViewCell {
     
     // MARK: - Properties
     
-    private lazy var datePicker: UIDatePicker = makeDatePicker()
+    lazy var datePicker: UIDatePicker = makeDatePicker()
     
     var dateChangeEnded: ((Date) -> ())?
     

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingDatePickerTableViewCell.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingDatePickerTableViewCell.swift
@@ -14,7 +14,6 @@ final class OnboardingDatePickerTableViewCell: UITableViewCell {
     // MARK: - Properties
     
     lazy var datePicker: UIDatePicker = makeDatePicker()
-    
     var dateChangeEnded: ((Date) -> ())?
     
     // MARK: - Life Cycles

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingDaysButtonTableViewCell.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingDaysButtonTableViewCell.swift
@@ -14,9 +14,7 @@ final class OnboardingDaysButtonTableViewCell: UITableViewCell {
     // MARK: - Properties
     
     private lazy var buttonContainer: VStackView = makeContainer()
-    
     var daysButtonSelectionState: [Bool]?
-    
     var action: ((Int, Bool) -> Void)?
 
     // MARK: - Life Cycles

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportImageCollectionViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportImageCollectionViewController.swift
@@ -14,7 +14,7 @@ final class ReportImageCollectionViewController: UICollectionViewController {
     // MARK: - Properties
     
     private let cellID = "reportImageCell"
-    private let itemSize: Int = 80
+    private let itemSize: Int = 74
     private var centeredItemIndex: IndexPath = [0, 0]
     
     // MARK: - Life Cycles

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportImageCollectionViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportImageCollectionViewController.swift
@@ -14,9 +14,7 @@ final class ReportImageCollectionViewController: UICollectionViewController {
     // MARK: - Properties
     
     private let cellID = "reportImageCell"
-    
     private let itemSize: Int = 80
-    
     private var centeredItemIndex: IndexPath = [0, 0]
     
     // MARK: - Life Cycles

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -19,15 +19,10 @@ final class ReportViewController: BaseViewController, BottomSheetPresentable {
         
         return calendar.component(.day, from: currentDate)
     }()
-    
     private lazy var headerView: HStackView = makeHeaderView()
-    
     private lazy var imageCollectionViewController: ReportImageCollectionViewController = makeImageCollectionViewController()
-    
     private lazy var calendarNaviView: VStackView = makeCalendarNaviView()
-    
     private lazy var gridView: VStackView = makeGridView(31) // 월마다 바뀌는 일 수 주입
-    
     private lazy var messageBoxView: UILabel = makeMessageBoxView("모두 완료하면 토마토가 웃는 얼굴이 돼요")
     
     // MARK: - Life Cycles
@@ -37,8 +32,10 @@ final class ReportViewController: BaseViewController, BottomSheetPresentable {
         
         setAddSubviews()
         setAutoLayout()
-//        getMonthHabitCompletedInfo() // 한달 동안의 습관 완료 여부 마찬가지로 임시로 만들어 둔것입니다. 안에 있는 로직 활용하시면 됩니다.
-//        getSelectedDayHabitInfo(selectedDay: "2024-03-07")
+        
+        getMonthHabitCompletedInfo() // 한달 동안의 습관 완료 여부 마찬가지로 임시로 만들어 둔것입니다. 안에 있는 로직 활용하시면 됩니다.
+        getSelectedDayHabitInfo(selectedDay: "2024-03-07")
+        getUserData()
     }
 }
 
@@ -313,7 +310,7 @@ extension ReportViewController {
     func getMonthHabitCompletedInfo() {
         do {
             let monthHabitCompletedInfo = try CoreDataManager.shared.fetchDailyHabitInfos().map{$0.hasDone} // 한달 동안의 습관 완료 기록, 습관을 시작하는날이 아닌경우에는 표시안됨
-            print(monthHabitCompletedInfo) // 테스트후 지우셔도 됩니다.
+            print("monthHabitCompletedInfo: ", monthHabitCompletedInfo) // 테스트후 지우셔도 됩니다.
         } catch {
             print(error)
         }
@@ -322,8 +319,9 @@ extension ReportViewController {
     func getSelectedDayHabitInfo(selectedDay: String) { // selectedDay 매개변수를 통해 해당하는 날짜의 습관정보를 불러옴, 날짜 형식 2024-03-08
         do {
             let habitInfos = try CoreDataManager.shared.fetchDailyHabitInfos()
+            print("habitInfos:", habitInfos)
             let habitInfoDays = habitInfos.compactMap{$0.day}
-            
+            print("habitInfoDays:", habitInfoDays)
             if let index = habitInfoDays.firstIndex(where: {$0 == selectedDay}) {
                 let selectedHabitInfo = habitInfos[index]
                 guard let day = selectedHabitInfo.day else { return }
@@ -339,11 +337,11 @@ extension ReportViewController {
     func getUserData() {
         do {
             let userData = try CoreDataManager.shared.fetchUser()
-            guard let nickname = userData?.nickname else { return } // 닉네임
-            guard let targetHabit = userData?.targetHabit else { return } // 할 습관
-            guard let targetDate = userData?.targetDate else { return } // 습관을 진행할 요일
-            guard let startTime = userData?.startTime else { return } // 습관 진행 시간
-            guard let whiteNoiseType = userData?.whiteNoiseType else { return } // 사운드
+            print("nickname: ", userData?.nickname)
+            print("targetHabit: ", userData?.targetHabit)
+            print("targetDate: ", userData?.targetDate)
+            print("startTime: ", userData?.startTime)
+            print("whiteNoiseType: ", userData?.whiteNoiseType)
         } catch {
             print(error)
         }

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -35,6 +35,9 @@ final class ReportViewController: BaseViewController, BottomSheetPresentable {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        getMonthHabitCompletedInfo()
+        getSelectedDayHabitInfo(selectedDay: "2024-03-08")
+        
         setAddSubviews()
         setAutoLayout()
     }
@@ -124,7 +127,7 @@ extension ReportViewController {
             })
             
             let habitEdit = UIAction(title: "습관 변경", handler: { _ in
-                self.presentBottomSheet(rootView: ReportHabitEditView(), detents: [.large()])
+                
             })
             
             let menus = UIMenu(children: [habitInfo, habitEdit])
@@ -214,12 +217,11 @@ extension ReportViewController {
             let boxView = {
                 let boxView = UIButton(type: .system, primaryAction: .init(handler: { _ in
                     print("day: \(day)")
+                    self.presentBottomSheet(rootView: ReportHabitDetailView(), detents: [.large()])
                 }))
-                
                 boxView.backgroundColor = .pobitRed
                 boxView.layer.cornerRadius = 10
                 boxView.alpha = day <= todayDate ? 1 : 0.1
-                
                 boxView.snp.makeConstraints { make in
                     make.width.equalTo(56)
                     make.height.equalTo(45)
@@ -313,8 +315,8 @@ extension ReportViewController {
 extension ReportViewController {
     private func getMonthHabitCompletedInfo() {
         do {
+            print("CoreDataManager.shared.fetchDailyHabitInfos: ", try CoreDataManager.shared.fetchDailyHabitInfos())
             let monthHabitCompletedInfo = try CoreDataManager.shared.fetchDailyHabitInfos().map{$0.hasDone} // 한달 동안의 습관 완료 기록, 습관을 시작하는날이 아닌경우에는 표시안됨
-            print("monthHabitCompletedInfo: ", monthHabitCompletedInfo) // 테스트후 지우셔도 됩니다.
         } catch {
             print(error)
         }
@@ -325,7 +327,6 @@ extension ReportViewController {
             let habitInfos = try CoreDataManager.shared.fetchDailyHabitInfos()
             print("habitInfos:", habitInfos)
             let habitInfoDays = habitInfos.compactMap{$0.day}
-            print("habitInfoDays:", habitInfoDays)
             if let index = habitInfoDays.firstIndex(where: {$0 == selectedDay}) {
                 let selectedHabitInfo = habitInfos[index]
                 guard let day = selectedHabitInfo.day else { return }

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -14,15 +14,16 @@ final class ReportViewController: BaseViewController, BottomSheetPresentable {
     // MARK: - Data Properties
     
     private lazy var user: User? = getUserData()
-    
-    // MARK: - UI Properties
-    
     private let todayDate = { // 오늘 날짜 정수
         let currentDate = Date()
         let calendar = Calendar.current
         
         return calendar.component(.day, from: currentDate)
     }()
+    
+    // MARK: - UI Properties
+    
+    private let navigationBar = PobitNavigationBarView(title: "이번달 습관 달성률", viewType: .plain)
     private lazy var headerView: HStackView = makeHeaderView()
     private lazy var imageCollectionViewController: ReportImageCollectionViewController = makeImageCollectionViewController()
     private lazy var calendarNaviView: VStackView = makeCalendarNaviView()
@@ -46,6 +47,7 @@ extension ReportViewController {
         addChild(imageCollectionViewController)
         
         view.addSubViews([
+            navigationBar,
             headerView,
             calendarNaviView,
             imageCollectionViewController.view,
@@ -55,24 +57,30 @@ extension ReportViewController {
     }
     
     private func setAutoLayout() {
+        navigationBar.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(58)
+        }
+        
         headerView.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            make.top.equalTo(navigationBar.snp.bottom)
             make.left.equalTo(LayoutLiterals.minimumHorizontalSpacing)
             make.right.equalTo(-LayoutLiterals.minimumHorizontalSpacing)
-            make.height.equalTo(55)
+            make.height.equalTo(50)
         }
         
         imageCollectionViewController.view.snp.makeConstraints { make in
             make.top.equalTo(headerView.snp.bottom)
             make.left.right.equalToSuperview()
-            make.height.equalTo(100)
+            make.height.equalTo(74)
         }
         
         calendarNaviView.snp.makeConstraints { make in
             make.top.equalTo(imageCollectionViewController.view.snp.bottom).offset(LayoutLiterals.upperPrimarySpacing)
             make.left.equalToSuperview().offset(35)
             make.right.equalToSuperview().offset(-35)
-            make.height.equalTo(55)
+            make.height.equalTo(44)
         }
         
         gridView.snp.makeConstraints { make in
@@ -81,10 +89,10 @@ extension ReportViewController {
         }
         
         messageBoxView.snp.makeConstraints { make in
-            make.height.equalTo(35)
-            make.top.equalTo(gridView.snp.bottom).offset(LayoutLiterals.upperSecondarySpacing)
             make.right.equalTo(view.snp.right).offset(-LayoutLiterals.minimumHorizontalSpacing)
+            make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-LayoutLiterals.upperSecondarySpacing)
             make.left.equalTo(view.snp.left).offset(LayoutLiterals.minimumHorizontalSpacing)
+            make.height.equalTo(35)
         }
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Report/Views/HabitEdit/ReportHabitDetailView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Views/HabitEdit/ReportHabitDetailView.swift
@@ -1,5 +1,5 @@
 //
-//  ReportHabitEditView.swift
+//  ReportHabitDetailView.swift
 //  PomoHabit
 //
 //  Created by JiHoon K on 2/29/24.
@@ -7,9 +7,9 @@
 
 import UIKit
 
-// MARK: - ReportHabitEditViewController
+// MARK: - ReportHabitDetailView
 
-final class ReportHabitEditView: BaseView { // 구현 중
+final class ReportHabitDetailView: BaseView {
     
     // MARK: - UI Properties
 
@@ -30,7 +30,7 @@ final class ReportHabitEditView: BaseView { // 구현 중
     }
 }
 
-extension ReportHabitEditView {
+extension ReportHabitDetailView {
     private func setAddSubviews() {
         addSubViews([
             headerView,
@@ -55,13 +55,13 @@ extension ReportHabitEditView {
 
 // MARK: - Factory Methods
 
-extension ReportHabitEditView {
+extension ReportHabitDetailView {
     private func makeHeaderView() -> VStackView {
         let dateLabel = {
             let label = UILabel()
-            label.text = "02.21 수요일"
-            label.font = Pretendard.bold(size: 20)
-            label.textColor = .darkGray
+            label.text = Date().dateToString()
+            label.font = Pretendard.bold(size: 50)
+            label.textColor = .pobitBlack
             
             return label
         }()

--- a/PomoHabit/PomoHabit/Presentation/Report/Views/HabitEdit/ReportHabitEditView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Views/HabitEdit/ReportHabitEditView.swift
@@ -14,7 +14,6 @@ final class ReportHabitEditView: BaseView { // 구현 중
     // MARK: - Properties
 
     private lazy var headerView: VStackView = makeHeaderView()
-    
     private lazy var mainContainerView: VStackView = makeMainContainerView()
     
     // MARK: - Life Cycles

--- a/PomoHabit/PomoHabit/Presentation/Report/Views/HabitEdit/ReportHabitEditView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Views/HabitEdit/ReportHabitEditView.swift
@@ -11,7 +11,7 @@ import UIKit
 
 final class ReportHabitEditView: BaseView { // 구현 중
     
-    // MARK: - Properties
+    // MARK: - UI Properties
 
     private lazy var headerView: VStackView = makeHeaderView()
     private lazy var mainContainerView: VStackView = makeMainContainerView()

--- a/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportDayButtonTableViewCell.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportDayButtonTableViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  ReportDayButtonCell.swift
+//  ReportDayButtonTableViewCell.swift
 //  PomoHabit
 //
 //  Created by JiHoon K on 2/29/24.
@@ -11,12 +11,15 @@ import UIKit
 
 final class ReportDayButtonTableViewCell: UITableViewCell {
     
-    // MARK: - Properties
+    // MARK: - Data Properties
+    
+    private let dayStates: [DayButton.Day] = [.mon, .tue, .wed, .thu, .fri, .sat, .sun]
+    var daysButtonSelectionState: [Bool]?
+    
+    // MARK: - UI Properties
     
     private var collectionViewCellID = "\(ReportDayButtonTableViewCell.self)CollectionViewCell"
     private lazy var dayButtonCollectionView: UICollectionView = makeCollectionView()
-    private let dayStates: [DayButton.Day] = [.mon, .tue, .wed, .thu, .fri, .sat, .sun]
-    var daysButtonSelectionState: [Bool]?
     
     // MARK: - Life Cycles
 

--- a/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportDayButtonTableViewCell.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportDayButtonTableViewCell.swift
@@ -14,12 +14,9 @@ final class ReportDayButtonTableViewCell: UITableViewCell {
     // MARK: - Properties
     
     private var collectionViewCellID = "\(ReportDayButtonTableViewCell.self)CollectionViewCell"
-    
     private lazy var dayButtonCollectionView: UICollectionView = makeCollectionView()
-    
     private let dayStates: [DayButton.Day] = [.mon, .tue, .wed, .thu, .fri, .sat, .sun]
-    
-    var dayButtonSelectionStates: [Bool]?
+    var daysButtonSelectionState: [Bool]?
     
     // MARK: - Life Cycles
 
@@ -83,7 +80,7 @@ extension ReportDayButtonTableViewCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: collectionViewCellID, for: indexPath)
         
-        let dayButton = DayButton(dayType: dayStates[indexPath.row], isSelected: dayButtonSelectionStates?[indexPath.row] ?? false) { _ in }
+        let dayButton = DayButton(dayType: dayStates[indexPath.row], isSelected: daysButtonSelectionState?[indexPath.row] ?? false) { _ in }
         dayButton.isUserInteractionEnabled = false
         dayButton.snp.makeConstraints { make in
             make.width.equalTo(65)

--- a/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportHabitInfoView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportHabitInfoView.swift
@@ -27,7 +27,7 @@ final class ReportHabitInfoView: BaseView {
         
         self.daysButtonSelectionState = daysButtonSelectionState
         self.startTime = startTime
-        
+
         setAddSubviews()
         setAutoLayout()
     }

--- a/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportHabitInfoView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportHabitInfoView.swift
@@ -14,8 +14,7 @@ final class ReportHabitInfoView: BaseView {
     // MARK: - Properties
     
     private lazy var tableView: UITableView = makeTableView()
-    
-    private var dayButtonSelectionStates = [true, true, true, true, false, false, false] // 유저가 입력했던 월화수 데이터 (임시)
+    private var daysButtonSelectionState: [Bool]? // 유저가 입력했던 월화수 데이터 (임시)
     
     // MARK: - Life Cycles
     
@@ -107,7 +106,7 @@ extension ReportHabitInfoView: UITableViewDataSource {
         switch indexPath.section {
         case 0:
             let cell = ReportDayButtonTableViewCell()
-            cell.dayButtonSelectionStates = dayButtonSelectionStates
+            cell.daysButtonSelectionState = daysButtonSelectionState
             
             return cell
         case 1:

--- a/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportHabitInfoView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportHabitInfoView.swift
@@ -62,6 +62,7 @@ extension ReportHabitInfoView {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.separatorStyle = .none
+        tableView.showsVerticalScrollIndicator = false
         
         return tableView
     }

--- a/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportHabitInfoView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportHabitInfoView.swift
@@ -1,5 +1,5 @@
 //
-//  ReportHabitInfoViewController.swift
+//  ReportHabitInfoView.swift
 //  PomoHabit
 //
 //  Created by JiHoon K on 2/29/24.
@@ -11,15 +11,22 @@ import UIKit
 
 final class ReportHabitInfoView: BaseView {
     
-    // MARK: - Properties
+    // MARK: - Data Properties
+    
+    private var daysButtonSelectionState: [Bool]? // 유저가 입력했던 월화수 데이터 (임시)
+    private var startTime: String?
+    
+    // MARK: - UI Properties
     
     private lazy var tableView: UITableView = makeTableView()
-    private var daysButtonSelectionState: [Bool]? // 유저가 입력했던 월화수 데이터 (임시)
     
     // MARK: - Life Cycles
     
-    override init(frame: CGRect) {
+    init(frame: CGRect, daysButtonSelectionState: [Bool]?, startTime: String?) {
         super.init(frame: frame)
+        
+        self.daysButtonSelectionState = daysButtonSelectionState
+        self.startTime = startTime
         
         setAddSubviews()
         setAutoLayout()
@@ -55,8 +62,6 @@ extension ReportHabitInfoView {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.separatorStyle = .none
-        tableView.register(ReportDayButtonTableViewCell.self, forCellReuseIdentifier: "\(ReportDayButtonTableViewCell.self)")
-        tableView.register(ReportDayButtonTableViewCell.self, forCellReuseIdentifier: "StartTimeCell")
         
         return tableView
     }
@@ -114,7 +119,7 @@ extension ReportHabitInfoView: UITableViewDataSource {
             cell.isUserInteractionEnabled = false
 
             let label = UILabel()
-            label.text = "8 : 40 AM"
+            label.text = self.startTime
             label.font = Pretendard.bold(size: 20)
             label.textColor = .secondaryLabel
             


### PR DESCRIPTION
##  작업한 내용
- 온보딩에서 등록하기 버튼 눌렀을때 유저 데이터를 CoreData에 생성.
- 리포트 뷰에서 습관 정보 뷰 바인딩.
- 리포트 뷰에서 네비바 탑제.

##  PR Point
- class OnboardingHabitRegisterViewController
    - **convertDataForCoreData()** 는 등록하기 버튼 눌렀을때 유저에게 받은 데이터를 코어 데이터에 저장하기 위해서 한번 데이터를 알맞게 변환해서 반환해주는 함수


## 스크린샷
<img width="327" alt="Screenshot 2024-03-11 at 9 24 06 AM" src="https://github.com/PlanLit/PomoHabit/assets/73418225/a5c6c356-d564-424d-a06a-25811b382a41">


## 관련 이슈
- 리포트에서 습관 변경 버튼을 눌렀을때 나오는 뷰를 생각하지 못해서 생각해봐야 할거 같습니다. 어떤걸 변경하게 해줄건지랑.
- 현재 코어 데이터에서 이전에 완료했던 습관 정보를 불러오는 방법을 논의 해봐야할거같고, 저번 금요일에 달력 컨셉말고 그냥 깃허브 잔디 느낌으로 갈지 말지 말 나온김에 일단 한 만큼 공유해야 할거 같아서 푸시 합니다.
- SceneDelegate에서 유저 데이터가 있을때, 온보딩으로 안가고 탭바로 바로 가는 로직 필요할 거 같습니다.

- Resolved: #59
