### PR TITLE
Feat/#59 - 온보딩 로그인 및 등록하기 뷰에서 키보드 관련 UX 개선 및 기타 리팩토링

### DIFF
--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
@@ -13,7 +13,7 @@ final class OnboardingHabitRegisterViewController: BaseViewController {
     
     // MARK: - Data Properties
     
-    var nickName: String?
+    private var nickName: String?
     private var habitTitle: String?
     private var daysButtonSelectionState: [Bool] = [false, false, false, false, false, false, false]
     private var habitStartTime: Date?
@@ -167,8 +167,7 @@ extension OnboardingHabitRegisterViewController {
     
     private func makeOnboardingDaysButtonTableViewCell() -> OnboardingDaysButtonTableViewCell {
         let cell = OnboardingDaysButtonTableViewCell()
-        cell.daysButtonSelectionState = daysButtonSelectionState
-        cell.action = { inx, state in
+        cell.setData(daysButtonSelectionState) { inx, state in
             self.daysButtonSelectionState[inx] = state
             var trueCount = 0
             for state in self.daysButtonSelectionState {
@@ -191,8 +190,7 @@ extension OnboardingHabitRegisterViewController {
     
     private func makeOnboardingDatePickerTableViewCell(_ indexPath: IndexPath) -> OnboardingDatePickerTableViewCell {
         let cell = OnboardingDatePickerTableViewCell()
-        cell.datePicker.date = habitStartTime ?? Date()
-        cell.dateChangeEnded = { [weak self] date in
+        cell.setData(habitStartTime ?? Date()) { [weak self] date in
             if self?.habitStartTime == nil {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                     self?.addTableViewCellDataAndUpdate(.init(chatDirection: .incoming, message: "좋아 다 됬어! 우리 꼭 습관을 만들어보자!"))
@@ -365,6 +363,10 @@ extension OnboardingHabitRegisterViewController {
 // MARK: - Data Helpers
 
 extension OnboardingHabitRegisterViewController {
+    func setData(_ nickname: String?) {
+        self.nickName = nickname
+    }
+    
     private func convertDataForCoreData() -> (nickName: String, targetHabit: String, targetDate: String, startTime: String, whiteNoiseType: String?) {
         // 무슨 요일
         var targetDate = ""

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
@@ -90,6 +90,8 @@ extension OnboardingHabitRegisterViewController {
         tableView.separatorStyle = .none
         tableView.backgroundColor = .pobitSkin
         tableView.allowsSelection = false
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
+        tableView.addGestureRecognizer(tapGesture)
         
         return tableView
     }
@@ -332,6 +334,14 @@ extension OnboardingHabitRegisterViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
+    }
+}
+
+// MARK: - Action Helpers
+
+extension OnboardingHabitRegisterViewController {
+    @objc func hideKeyboard() {
+        view.endEditing(true)
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
@@ -13,7 +13,7 @@ final class OnboardingLoginViewController: UIViewController {
     
     // MARK: - Data Properties
     
-    var nickName: String?
+    private var nickname: String?
     
     // MARK: - UI Properties
     
@@ -92,7 +92,7 @@ extension OnboardingLoginViewController {
     private func makeNextButton() -> UIButton {
         let button = UIButton(type: .custom, primaryAction: .init(handler: { _ in
             let onboardingHabitRegisterViewController = OnboardingHabitRegisterViewController()
-            onboardingHabitRegisterViewController.nickName = self.nickName
+            onboardingHabitRegisterViewController.setData(self.nickname)
             self.navigationController?.pushViewController(onboardingHabitRegisterViewController, animated: true)
         }))
         button.setImage(UIImage(named: "arrow"), for: .normal)
@@ -111,7 +111,7 @@ extension OnboardingLoginViewController {
 
 extension OnboardingLoginViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        nickName = textField.text
+        nickname = textField.text
         if textField.text != "" {
             nextButton.layer.opacity = 1
             nextButton.isUserInteractionEnabled = true

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
@@ -30,6 +30,10 @@ final class OnboardingLoginViewController: UIViewController {
         setAddSubviews()
         setAutoLayout()
     }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
 }
 
 // MARK: - Layout Helpers
@@ -46,7 +50,8 @@ extension OnboardingLoginViewController {
     private func setAutoLayout() {
         container.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.centerY.equalToSuperview().offset(-65)
+            make.centerY.equalToSuperview().offset(-65).priority(.low)
+            make.bottom.lessThanOrEqualTo(self.view.keyboardLayoutGuide.snp.top).offset(-LayoutLiterals.minimumVerticalSpacing).priority(.medium)
         }
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingDatePickerTableViewCell.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingDatePickerTableViewCell.swift
@@ -13,8 +13,8 @@ final class OnboardingDatePickerTableViewCell: UITableViewCell {
     
     // MARK: - Properties
     
-    lazy var datePicker: UIDatePicker = makeDatePicker()
-    var dateChangeEnded: ((Date) -> ())?
+    private lazy var datePicker: UIDatePicker = makeDatePicker()
+    private var dateChangeEnded: ((Date) -> ())?
     
     // MARK: - Life Cycles
     
@@ -48,6 +48,11 @@ extension OnboardingDatePickerTableViewCell {
             make.trailing.equalToSuperview().offset(-LayoutLiterals.minimumHorizontalSpacing)
             make.centerY.equalToSuperview()
         }
+    }
+    
+    func setData(_ date: Date,_ dateChangeEnded: ((Date) -> ())?) {
+        self.datePicker.date = date
+        self.dateChangeEnded = dateChangeEnded
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingDaysButtonTableViewCell.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingDaysButtonTableViewCell.swift
@@ -14,8 +14,8 @@ final class OnboardingDaysButtonTableViewCell: UITableViewCell {
     // MARK: - Properties
     
     private lazy var buttonContainer: VStackView = makeContainer()
-    var daysButtonSelectionState: [Bool]?
-    var action: ((Int, Bool) -> Void)?
+    private var daysButtonSelectionState: [Bool]?
+    private var action: ((Int, Bool) -> Void)?
 
     // MARK: - Life Cycles
     
@@ -49,6 +49,11 @@ extension OnboardingDaysButtonTableViewCell {
             make.trailing.equalToSuperview().offset(-LayoutLiterals.minimumHorizontalSpacing)
             make.centerY.equalToSuperview()
         }
+    }
+    
+    func setData(_ daysButtonSelectionState: [Bool]?,_ action:((Int, Bool) -> Void)?) {
+        self.daysButtonSelectionState = daysButtonSelectionState
+        self.action = action
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportDayButtonTableViewCell.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportDayButtonTableViewCell.swift
@@ -14,7 +14,7 @@ final class ReportDayButtonTableViewCell: UITableViewCell {
     // MARK: - Data Properties
     
     private let dayStates: [DayButton.Day] = [.mon, .tue, .wed, .thu, .fri, .sat, .sun]
-    var daysButtonSelectionState: [Bool]?
+    private var daysButtonSelectionState: [Bool]?
     
     // MARK: - UI Properties
     
@@ -94,5 +94,13 @@ extension ReportDayButtonTableViewCell: UICollectionViewDataSource {
         cell.contentView.addSubview(dayButton)
         
         return cell
+    }
+}
+
+// MARK: - Data Helpers
+
+extension ReportDayButtonTableViewCell {
+    func initData(_ daysButtonSelectionState: [Bool]?) {
+        self.daysButtonSelectionState = daysButtonSelectionState
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportHabitInfoView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Views/HabitInfo/ReportHabitInfoView.swift
@@ -112,7 +112,7 @@ extension ReportHabitInfoView: UITableViewDataSource {
         switch indexPath.section {
         case 0:
             let cell = ReportDayButtonTableViewCell()
-            cell.daysButtonSelectionState = daysButtonSelectionState
+            cell.initData(daysButtonSelectionState)
             
             return cell
         case 1:


### PR DESCRIPTION
##  작업한 내용
- 프로퍼티들 private화
- 온보딩 로그인 화면에서 키보드가 뷰 가리는 문제 개선
- 온보딩 로그인 및 등록 뷰에서 키보드 올라와있을때 뒤에 백그라운드 터치시 닫히게 사용성 개선

##  PR Point
- **touchesBegan()** 는 뷰가 터치를 감지하는 override 메서드

## 스크린샷


## 관련 이슈

- Resolved: #59 
