### PR TITLE
[Fix] #73 weekly calendar binding [Chore] 피드백반영 [Feat] 수정기능 추가

### DIFF
--- a/PomoHabit/PomoHabit/Global/CoreData/CoreDataManager.swift
+++ b/PomoHabit/PomoHabit/Global/CoreData/CoreDataManager.swift
@@ -163,12 +163,12 @@ extension CoreDataManager {
 // MARK: - MockData
 
 extension CoreDataManager {
-    func setMockupTotalHabitInfo(today: Date,targetDate: String) { // 목업 데이터 생성
+    func setMockupTotalHabitInfo(targetDate: String) { // 목업 데이터 생성
         let targetDayInfos = targetDate.split(separator: ",").map{String($0)}
         let calendar = Calendar.current
         var appendCount = 0
         var goalTime = 5
-        var date = today
+        var date = Date()
         
         if targetDayInfos.contains(date.getDayOfWeek()){ // 오늘 습관을 진행하는 날짜인지 확인후 목데이터에 추가
             createTotalHabitInfo(date: date, goalTime: Int16(goalTime), hasDone: false, note: "")

--- a/PomoHabit/PomoHabit/Global/CoreData/CoreDataManager.swift
+++ b/PomoHabit/PomoHabit/Global/CoreData/CoreDataManager.swift
@@ -144,6 +144,21 @@ extension CoreDataManager {
     }
 }
 
+// MARK: - MyPage
+
+extension CoreDataManager {
+    func updateUsernickName(nickname: String) {
+        do {
+            let userData = try fetchUser()
+            
+            userData?.setValue(nickname, forKey: "nickname")
+            saveContext()
+        } catch {
+            print(error)
+        }
+    }
+}
+
 
 // MARK: - Timer
 

--- a/PomoHabit/PomoHabit/Global/Extensions/Date+Extension.swift
+++ b/PomoHabit/PomoHabit/Global/Extensions/Date+Extension.swift
@@ -11,6 +11,7 @@ extension Date {
     func dateToString(format : String = "MM.dd") -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = format
+        formatter.locale = Locale(identifier: "ko_KR")
         
         return formatter.string(from: self)
     }

--- a/PomoHabit/PomoHabit/Global/Supports/ViewController.swift
+++ b/PomoHabit/PomoHabit/Global/Supports/ViewController.swift
@@ -20,7 +20,7 @@ extension ViewController { // CoreData 활용 예시, 뷰 바인딩 끝난후 �
         do{
             let userInfo = try CoreDataManager.shared.fetchUser()
             guard let dayInfos = userInfo?.targetDate else { return }
-            CoreDataManager.shared.setMockupTotalHabitInfo(today: Date(), targetDate: dayInfos)
+            CoreDataManager.shared.setMockupTotalHabitInfo(targetDate: dayInfos)
         } catch {
             print(error)
         }

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
@@ -13,7 +13,7 @@ import SnapKit
 
 final class WeeklyCalendarViewController: BaseViewController {
     var weeklyDates: [Date] = []
-    
+    var weeklyHabitState: [HabitState] = []
     // MARK: - Properties
     
     private lazy var weeklyCalendarView: WeeklyCalendarView = {
@@ -36,6 +36,9 @@ final class WeeklyCalendarViewController: BaseViewController {
     
     override func viewDidLayoutSubviews() { // 해당 메소드 안에서만 오토레이 아웃으로 설정된 UI/View의 Frame 사이즈를 알 수 있음
         super.viewDidLayoutSubviews()
+        let progress = Float(weeklyHabitState.filter{$0 == .done}.count) / 7.0
+        
+        setUpWeeklyHabbitProgressView(progress: progress)
     }
 }
 
@@ -67,7 +70,7 @@ extension WeeklyCalendarViewController {
 extension WeeklyCalendarViewController {
     private func setUpWeeklyHabbitProgressView(progress : Float) {
         let weeklyCalendarViewWidth = weeklyCalendarView.frame.width
-        let progressCircleOffset = Int(weeklyCalendarViewWidth * CGFloat(progress)) - 5
+        let progressCircleOffset = Int(weeklyCalendarViewWidth * CGFloat(progress)) - 15
         
         weeklyCalendarView.setProgressCircleImg(offset: progressCircleOffset)
         weeklyCalendarView.setWeeklyHabitProgressView(progress: progress)
@@ -104,7 +107,7 @@ extension WeeklyCalendarViewController {
     }
     
     private func getWeeklyHabitState() {
-        var weeklyHabitState: [HabitState] = []
+      
         do {
             for date in weeklyDates {
                 let dateHabitState = try CoreDataManager.shared.getSelectedHabitInfo(selectedDate: date).map{$0.hasDone}

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
@@ -12,13 +12,11 @@ import SnapKit
 // MARK: - WeeklyCalendarViewController
 
 final class WeeklyCalendarViewController: BaseViewController {
+    var weeklyDates: [Date] = []
     
     // MARK: - Properties
     
-    var year : Int = 0
-    var month : Int = 0
-    
-    private lazy var weeklyCalendarView : WeeklyCalendarView = {
+    private lazy var weeklyCalendarView: WeeklyCalendarView = {
         let view = WeeklyCalendarView()
         view.dateDelegate = self
         
@@ -33,18 +31,11 @@ final class WeeklyCalendarViewController: BaseViewController {
         setWeeklyData()
         setAddSubViews()
         setSetAutoLayout()
+        getWeeklyHabitState()
     }
     
     override func viewDidLayoutSubviews() { // 해당 메소드 안에서만 오토레이 아웃으로 설정된 UI/View의 Frame 사이즈를 알 수 있음
         super.viewDidLayoutSubviews()
-//        do {
-//            let weeklyHasDoneCount = try CoreDataManager.shared.fetchDailyHabitInfos().filter{ $0.hasDone == true }.count
-//            
-//            setUpWeeklyHabbitProgressView(progress: Float(weeklyHasDoneCount) / 7.0)
-//        } catch {
-//            print(error)
-//        }
-        
     }
 }
 
@@ -82,7 +73,7 @@ extension WeeklyCalendarViewController {
         weeklyCalendarView.setWeeklyHabitProgressView(progress: progress)
     }
     
-    private func setUPWeeklyHabbitInfoView(state: HabitState, targetHabit: String, duringTime: String, goalTime: String, note: String) {
+    func setUPWeeklyHabbitInfoView(state: HabitState, targetHabit: String, duringTime: String, goalTime: String, note: String) {
         weeklyCalendarView.setHabitInfoView(state: state, targetHabit: targetHabit, duringTime: duringTime, goalTime: goalTime)
         weeklyCalendarView.setNoteContentLabel(note: note)
     }
@@ -92,85 +83,55 @@ extension WeeklyCalendarViewController {
 
 extension WeeklyCalendarViewController {
     private func setWeeklyData() {
-        var weeklyDates : [Int] = []
         let calendar = Calendar.current
         
         // MARK: - 현재 주의 시작 날짜
         
-        guard let result = calendar.dateInterval(of: .weekOfYear, for: Date()) else { return } // 현재 날짜가 속해 있는 주의 첫번째/마지막 날짜
-        guard let weeklyStartDate = calendar.date(byAdding: .day, value: 1, to: result.start)?.dateToString(format: "dd") else { return }
+        guard let startDate = calendar.dateInterval(of: .weekOfYear, for: Date())?.start else { return }
         
-        // MARK: - 현재 주의 마지막 날짜
+        // 주간 캘린더를 월요일부터 시작하기
         
-        let components = calendar.dateComponents([.year, .month], from: Date()) // 현재 날짜의 년도와 월
-        guard let thisYer = components.year else { return }
-        guard let thisMonth = components.month else { return }
-        
-        year = thisYer
-        month = thisMonth
-        
-        guard let currentStartDate = calendar.date(from: components) else { return } // 날짜와 년도를 가지고 가장 첫번째 날짜 Get
-        guard let nextStartDate = calendar.date(byAdding: .month, value: 1, to: currentStartDate) else {return} // 다음 달의 가장 첫번쨰날
-        guard let currentEndDate = calendar.date(byAdding: .day, value: -1, to: nextStartDate)?.dateToString(format: "dd") else {return} // 다음달의 가장 첫번째날 이전날 = 이번달의 마지막날
+        guard let mondayDate = calendar.date(byAdding: .day, value: 1, to: startDate) else { return }
         
         // MARK: - 주간 데이터 구하기
         
-        guard let weeklyStartDateInt = Int(weeklyStartDate) else { return }
-        guard let currentEndDateInt = Int(currentEndDate) else { return }
-        
         for i in 0...6 {
-            let date = weeklyStartDateInt + i
-            
-            if date <= currentEndDateInt {
-                weeklyDates.append(date)
-            } else {
-                weeklyDates.append(date - currentEndDateInt)
-            }
+            guard let date = calendar.date(byAdding: .day, value: i, to: mondayDate) else { return }
+            weeklyDates.append(date)
         }
 
         weeklyCalendarView.setWeeklyDates(weeklyDates: weeklyDates)
     }
     
-    func getSelectedDayHabitInfo(selectedDay : String) {
-//        do {
-//            let habitInfos = try CoreDataManager.shared.fetchDailyHabitInfos() // Daily 습관 정보 배열
-//            let userInfo = try CoreDataManager.shared.fetchUser() // 유저 정보
-//            let habitInfoDays = habitInfos.compactMap{$0.day} // Daily 습관 날짜 정보 배열
-//            guard let targetHabit = userInfo?.targetHabit else { return } // 설정한 습관
-//            var dateStr = Date().dateToString(format: "yyyy-MM-dd") // 앞에 년도를 붙여주기 위함
-//            
-//            guard let startTime = userInfo?.startTime else { return } // 습관 시작 시간
-//            dateStr += " " + startTime
-//            guard let startTimeTypeDate = dateStr.getStringToDate(format: "yyyy-MM-dd HH:mm") else { return }
-//            
-//            if let index = habitInfoDays.firstIndex(where: { $0 == selectedDay }) { // 선택한 날짜에 대한 습관 정보
-//                let selectedHabitInfo = habitInfos[index]
-//                let goalTime = selectedHabitInfo.goalTime
-//                let hasDone = selectedHabitInfo.hasDone ? HabitState.done : HabitState.doNot
-//                guard let note = selectedHabitInfo.note else { return }
-//                guard let endTime = Calendar.current.date(byAdding: .minute, value: Int(goalTime), to: startTimeTypeDate) else { return }
-//                let duringTime = startTimeTypeDate.dateToString(format: "HH:mm") + "~" + endTime.dateToString(format: "HH:mm")
-//                
-//                setUPWeeklyHabbitInfoView(state: hasDone, targetHabit: targetHabit, duringTime: duringTime, goalTime: "\(goalTime)", note: note)
-//            } else {
-//                setUPWeeklyHabbitInfoView(state: .doNot, targetHabit: "습관 이름", duringTime: "00:00~00:00", goalTime: "0", note: "시작하지 않은 습관입니다.")
-//            }
-//        } catch {
-//            print(error)
-//        }
+    private func getWeeklyHabitState() {
+        var weeklyHabitState: [HabitState] = []
+        do {
+            for date in weeklyDates {
+                let dateHabitState = try CoreDataManager.shared.getSelectedHabitInfo(selectedDate: date).map{$0.hasDone}
+                
+                switch dateHabitState{
+                case nil:
+                    weeklyHabitState.append(.notStart)
+                case true:
+                    weeklyHabitState.append(.done)
+                case false:
+                    weeklyHabitState.append(.doNot)
+                case .some(_):
+                    break
+                }
+            }
+            
+            weeklyCalendarView.setWeeklyHabitState(setData: weeklyHabitState)
+        } catch {
+            print(error)
+        }
     }
 }
 
 // MARK: - Delegate
 
 extension WeeklyCalendarViewController: SendSelectedData{
-    func sendDate(date: Int) {
-        var dateStr = String(year)
-        
-        dateStr += month < 10 ? "-0\(month)" : "-\(month)"
-        dateStr += date < 10 ? "-0\(date)" : "-\(date)"
-        
-        getSelectedDayHabitInfo(selectedDay: dateStr)
+    func sendDate(date: Date) { // 선택한 셀의 날짜
+   
     }
-    
 }

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
@@ -12,10 +12,13 @@ import SnapKit
 // MARK: - WeeklyCalendarViewController
 
 final class WeeklyCalendarViewController: BaseViewController {
-    var weeklyDates: [Date] = []
-    var weeklyHabitState: [HabitState] = []
+    private var weeklyDates: [Date] = []
+    private var weeklyHabitState: [HabitState] = []
+    
     // MARK: - Properties
+    
     var targetHabit: String?
+    
     private lazy var weeklyCalendarView: WeeklyCalendarView = {
         let view = WeeklyCalendarView()
         view.dateDelegate = self

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
@@ -152,17 +152,26 @@ extension WeeklyCalendarViewController: SendSelectedData{
     func sendDate(date: Date) { // 선택한 셀의 날짜
         do {
             let selectedHabiInfo = try CoreDataManager.shared.getSelectedHabitInfo(selectedDate: date) // 선택한 습관 정보
+            
+            if selectedHabiInfo == nil { // 쉬는날 or 습관 시작하기 전날
+                weeklyCalendarView.setHabitInfoView(state: .notStart, targetHabit: targetHabit ?? "설정한 습관", duringTime: "00:00 ~ 00:00", goalTime: 0)
+                weeklyCalendarView.setNoteContentLabel(note: "쉬는날 또는 습관 시작 하기 전날입니다.")
+            }
+            
             guard let selectedHabitState = selectedHabiInfo?.hasDone else { return } // 선택한 습관 상태
             let habitstate = selectedHabitState ? HabitState.done : HabitState.notStart // treu : false 처리
+            
             guard let goalTime = selectedHabiInfo?.goalTime else { return } // 목표 시간
             var duringTime = getDuringTime(completedDate: selectedHabiInfo?.date ?? Date(), goalTime: goalTime) // 습관 진행 기간
             
             if !selectedHabitState {
                 duringTime = "00:00 ~ 00:00"
             }
-                
+            
             weeklyCalendarView.setHabitInfoView(state: habitstate, targetHabit: targetHabit ?? "설정한 습관", duringTime: duringTime, goalTime: goalTime)
+            weeklyCalendarView.setNoteContentLabel(note: selectedHabiInfo?.note ?? "")
         } catch {
+            
             print(error)
         }
     }

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarHabitInfoView.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarHabitInfoView.swift
@@ -97,7 +97,7 @@ extension WeeklyCalendarHabitInfoView {
         timeInfoView.setUplabel(text: duringTime, font: Pretendard.medium(size: 15))
     }
     
-    func setTargetInfoView(goalTime: String) {
+    func setTargetInfoView(goalTime: Int16) {
         targetInfoView.setUplabel(text: "목표시간 : \(goalTime)m", font: Pretendard.medium(size: 15))
     }
     

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 
 protocol SendSelectedData{
-    func sendDate(date: Int)
+    func sendDate(date: Date)
 }
 
 // MARK: - WeeklyCalendarView
@@ -18,12 +18,10 @@ protocol SendSelectedData{
 final class WeeklyCalendarView: BaseView {
     
     // MARK: - Properties
-    
+    var weeklyHabitState: [HabitState] = []
     let weeklyDays = ["월","화","수","목","금","토","일"]
-    var weeklyDatesData : [Int] = []
+    var weeklyDatesData : [Date] = []
     var dateDelegate: SendSelectedData?
-    let habitStates = [HabitState.done,HabitState.doNot,HabitState.done,HabitState.notStart,HabitState.notStart,HabitState.notStart,HabitState.notStart] // 임시 데이터
-    
     
     // MARK: - DividerView
     
@@ -241,8 +239,12 @@ extension WeeklyCalendarView {
         }
     }
     
-    func setWeeklyDates(weeklyDates : [Int]) {
+    func setWeeklyDates(weeklyDates : [Date]) {
         weeklyDatesData = weeklyDates
+    }
+    
+    func setWeeklyHabitState(setData: [HabitState]) {
+        weeklyHabitState = setData
     }
     
     func setHabitInfoView(state: HabitState, targetHabit: String,duringTime: String,goalTime: String) {
@@ -289,9 +291,12 @@ extension WeeklyCalendarView: UICollectionViewDataSource {
         
         cell.setDayLabelText(text: weeklyDays[indexPath.item])
         cell.setDateLabelText(text: weeklyDatesData[indexPath.item])
-        cell.setCellBackgroundColor(state: habitStates[indexPath.item])
+        cell.setCellBackgroundColor(state: weeklyHabitState[indexPath.item])
         
         return cell
     }
 }
+
+// MARK: - GetData
+
 

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
@@ -254,7 +254,11 @@ extension WeeklyCalendarView {
     }
     
     func setNoteContentLabel(note: String) {
-        noteContentLabel.text = note
+        if note == "" {
+            noteContentLabel.text = "메모를 입력하지 않았습니다."
+        } else {
+            noteContentLabel.text = note
+        }
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
@@ -247,7 +247,7 @@ extension WeeklyCalendarView {
         weeklyHabitState = setData
     }
     
-    func setHabitInfoView(state: HabitState, targetHabit: String,duringTime: String,goalTime: String) {
+    func setHabitInfoView(state: HabitState, targetHabit: String,duringTime: String,goalTime: Int16) {
         habitInfoView.setTitleInfoView(state: state, targetHabit: targetHabit)
         habitInfoView.setTimeInfoView(duringTime: duringTime)
         habitInfoView.setTargetInfoView(goalTime: goalTime)

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
@@ -220,7 +220,7 @@ extension WeeklyCalendarView {
     }
     
     private func setSubTitleLabel() {
-        weeklyHabitProgressLabel.setSubTitleLabel(text: "진행 상태")
+        weeklyHabitProgressLabel.setSubTitleLabel(text: "주간 달성율")
         habitInfoLabel.setSubTitleLabel(text: "습관 정보")
         noteInfoLabel.setSubTitleLabel(text: "메모")
     }

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCollectionViewCell.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCollectionViewCell.swift
@@ -92,8 +92,8 @@ extension WeeklyCollectionViewCell{
         dayLabel.text = text
     }
     
-    func setDateLabelText(text: Int) { // 임시
-        dateLabel.text = "\(text)"
+    func setDateLabelText(text: Date) {
+        dateLabel.text = text.dateToString(format: "dd")
     }
     
     func setCellBackgroundColor(state: HabitState) { //습관 정보에 따라 달라지는 cell배경및 border 함수

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/model/WeeklyCalendarModel.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/model/WeeklyCalendarModel.swift
@@ -8,10 +8,10 @@ import UIKit
 
 import SnapKit
 
-enum HabitState : Int{
-    case done = 0
-    case doNot = 1
-    case notStart = 2
+enum HabitState{
+    case done
+    case doNot
+    case notStart
 }
 
 extension HabitState {


### PR DESCRIPTION
##  작업한 내용
- CordData 목데이터 생성 피드백 반영
- 주간 캘린너 날짜  습관 상태 바인딩
- 날짜 변환 한국기준고정
- 주간 달성율 데이터 전처리후 바인딩
- 습관 정보 뷰 바인딩
- 메모입력/미입력 분기 처리
- 쉬는날/습관진행날 분기 처리
- 닉네임 수정 기능
##  PR Point
- Date+Extension 14번째줄 추가 한국날짜 지정, 다른나라에서도 한국기준으로 표시 추후 다른나라에서도 사용시 삭제필요
Default값 : 기기의 locale(언어 및 지역설정) 
- CoreDataManager updateUsernickName : 닉네임 변경 함수 추가하였습니다. @Lilyhly merege후에 develop pull하셔서 사용하시면 됩니다. 변경된 닉네임만 파라미터에 넣으시면 닉네임 변경됩니다!
## 스크린샷

|뷰|설명|
|------|---|
<img src="https://github.com/PlanLit/PomoHabit/assets/82082770/3d48e613-23f7-42d6-be4d-96abdbfef521" width = "300" >| 주간 캘린더 진입 화면입니다. 주간 캘린더를 입력하지 않은경우|
<img src="https://github.com/PlanLit/PomoHabit/assets/82082770/251d1e25-ed83-4403-a19d-bff59f96ce25" width = "300" >| 쉬는날/해당하지 않는날 클릭|
<img src="https://github.com/PlanLit/PomoHabit/assets/82082770/01211073-6b3e-40e4-9bf3-53ecd1affda3" width = "300" >| 습관 완료한날 클릭|
<img src="https://github.com/PlanLit/PomoHabit/assets/82082770/64f6b460-1cd5-40d3-ac52-b26762ceb059" width = "300" >| 습관 완료하지 않은 날 클릭, 메모입력 안했을경우|


## 관련 이슈
- Resolved: #73 #69
