### PR TITLE
[Chore] #79 - bottomSheetPresentable 수정

### DIFF
--- a/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
+++ b/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
@@ -35,8 +35,8 @@
 		378034A32B8F8D8A0046E6B8 /* PomoProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376278222B8F88FB00BA7373 /* PomoProgressBar.swift */; };
 		378034A42B8F8D8D0046E6B8 /* PomoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376278232B8F88FF00BA7373 /* PomoModel.swift */; };
 		378034A82B8F9C810046E6B8 /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378034A72B8F9C810046E6B8 /* BottomSheetViewController.swift */; };
-		378034AB2B8F9D7A0046E6B8 /* MemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378034AA2B8F9D7A0046E6B8 /* MemoView.swift */; };
-		378034AD2B8FAB5B0046E6B8 /* WhiteNoiseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378034AC2B8FAB5B0046E6B8 /* WhiteNoiseView.swift */; };
+		378034AB2B8F9D7A0046E6B8 /* MemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378034AA2B8F9D7A0046E6B8 /* MemoViewController.swift */; };
+		378034AD2B8FAB5B0046E6B8 /* WhiteNoiseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378034AC2B8FAB5B0046E6B8 /* WhiteNoiseViewController.swift */; };
 		378034AF2B8FACE50046E6B8 /* WhiteNoiseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378034AE2B8FACE50046E6B8 /* WhiteNoiseTableViewCell.swift */; };
 		37B811CD2B9B74BE00A6694E /* InputOutputProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B811CC2B9B74BE00A6694E /* InputOutputProtocol.swift */; };
 		37B811CF2B9B76F100A6694E /* Combine+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B811CE2B9B76F100A6694E /* Combine+Extensions.swift */; };
@@ -113,8 +113,8 @@
 		376B91B62B8C6AF6004CBB16 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		376B91B92B8CE6B6004CBB16 /* PobitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PobitButton.swift; sourceTree = "<group>"; };
 		378034A72B8F9C810046E6B8 /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
-		378034AA2B8F9D7A0046E6B8 /* MemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoView.swift; sourceTree = "<group>"; };
-		378034AC2B8FAB5B0046E6B8 /* WhiteNoiseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteNoiseView.swift; sourceTree = "<group>"; };
+		378034AA2B8F9D7A0046E6B8 /* MemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoViewController.swift; sourceTree = "<group>"; };
+		378034AC2B8FAB5B0046E6B8 /* WhiteNoiseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteNoiseViewController.swift; sourceTree = "<group>"; };
 		378034AE2B8FACE50046E6B8 /* WhiteNoiseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteNoiseTableViewCell.swift; sourceTree = "<group>"; };
 		37B811CC2B9B74BE00A6694E /* InputOutputProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputOutputProtocol.swift; sourceTree = "<group>"; };
 		37B811CE2B9B76F100A6694E /* Combine+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Combine+Extensions.swift"; sourceTree = "<group>"; };
@@ -380,8 +380,8 @@
 		378034A92B8F9D360046E6B8 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				378034AA2B8F9D7A0046E6B8 /* MemoView.swift */,
-				378034AC2B8FAB5B0046E6B8 /* WhiteNoiseView.swift */,
+				378034AA2B8F9D7A0046E6B8 /* MemoViewController.swift */,
+				378034AC2B8FAB5B0046E6B8 /* WhiteNoiseViewController.swift */,
 				378034AE2B8FACE50046E6B8 /* WhiteNoiseTableViewCell.swift */,
 			);
 			path = Views;
@@ -654,7 +654,7 @@
 				F88EB2D82B8DC0EB0073BDDA /* WeeklyCalendarModel.swift in Sources */,
 				F8A4FB992B96F2A300E46EA1 /* ReportHabitDetailView.swift in Sources */,
 				BAFEE1542B96F900009F0D25 /* MypageTableViewCell.swift in Sources */,
-				378034AD2B8FAB5B0046E6B8 /* WhiteNoiseView.swift in Sources */,
+				378034AD2B8FAB5B0046E6B8 /* WhiteNoiseViewController.swift in Sources */,
 				F8E3CD3A2B8C7FF200712CBF /* NoteTextView.swift in Sources */,
 				F870D85C2B8EFF3900DA4659 /* UILabel+Extension.swift in Sources */,
 				F85F8F5B2B8DF0D500E69922 /* WeeklyCollectionViewCell.swift in Sources */,
@@ -672,7 +672,7 @@
 				F8A4FB962B96F2A300E46EA1 /* ReportViewController.swift in Sources */,
 				37B811CD2B9B74BE00A6694E /* InputOutputProtocol.swift in Sources */,
 				37144C6A2B8C32D6008565C4 /* ViewController.swift in Sources */,
-				378034AB2B8F9D7A0046E6B8 /* MemoView.swift in Sources */,
+				378034AB2B8F9D7A0046E6B8 /* MemoViewController.swift in Sources */,
 				E0C5B53E2B8D5B2700A77BAE /* DayButton.swift in Sources */,
 				E0BEE14B2B99366600A2C4C4 /* OnboardingChattingCellData.swift in Sources */,
 				378034A12B8F8D830046E6B8 /* PomoViewController.swift in Sources */,

--- a/PomoHabit/PomoHabit/Global/Components/Modal/BottomSheetPresentable.swift
+++ b/PomoHabit/PomoHabit/Global/Components/Modal/BottomSheetPresentable.swift
@@ -13,8 +13,8 @@ import UIKit
  prefersGrabberVisible - 상단 중앙에 위치한 수평 바
  */
 
-protocol BottomSheetPresentable: UIViewController, UISheetPresentationControllerDelegate {
-    func presentBottomSheet(rootView: UIView, detents: [UISheetPresentationController.Detent], prefersGrabberVisible: Bool)
+protocol BottomSheetPresentable:UIViewController, UISheetPresentationControllerDelegate {
+    func presentBottomSheet(viewController: UIViewController, detents: [UISheetPresentationController.Detent], prefersGrabberVisible: Bool)
 }
 
 extension BottomSheetPresentable {
@@ -24,8 +24,9 @@ extension BottomSheetPresentable {
         sheet.prefersGrabberVisible = prefersGrabberVisible
     }
     
-    func presentBottomSheet(rootView: UIView, detents: [UISheetPresentationController.Detent] = [.large()], prefersGrabberVisible: Bool = true) {
-        let viewController = BottomSheetViewController(rootView: rootView)
+    func presentBottomSheet(viewController: UIViewController, detents: [UISheetPresentationController.Detent] = [.large()], prefersGrabberVisible: Bool = true) {
+        let viewController = viewController
+        viewController.view.backgroundColor = .pobitWhite
         
         guard let sheet = viewController.sheetPresentationController else { return }
         setupSheet(sheet, with: detents, prefersGrabberVisible: prefersGrabberVisible)

--- a/PomoHabit/PomoHabit/Global/Components/Modal/Views/MemoViewController.swift
+++ b/PomoHabit/PomoHabit/Global/Components/Modal/Views/MemoViewController.swift
@@ -11,31 +11,27 @@ import SnapKit
 
 // MARK: - MemoView
 
-final class MemoView: BaseView {
+final class MemoViewController: BaseViewController {
 
     // MARK: - UI Properties
     
     private lazy var navigationBar = PobitNavigationBarView(title: "메모", viewType: .withDismissButton)
     private lazy var textView = NoteTextView()
     private lazy var submitButton = PobitButton.makePlainButton(title: "등록하기", backgroundColor: .pobitRed)
+
+    // MARK: - Life Cycle
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        
+    override func viewDidLoad() {
         setAddSubViews()
         setAutoLayout()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 }
 
 // MARK: - Layout Helpers
 
-extension MemoView {
+extension MemoViewController {
     private func setAddSubViews() {
-        addSubViews([navigationBar, textView, submitButton])
+        view.addSubViews([navigationBar, textView, submitButton])
     }
     
     private func setAutoLayout() {
@@ -52,7 +48,7 @@ extension MemoView {
         }
         
         submitButton.snp.makeConstraints { make in
-            make.bottom.equalTo(keyboardLayoutGuide.snp.top).offset(-LayoutLiterals.minimumHorizontalSpacing)
+            make.bottom.equalTo(view.keyboardLayoutGuide.snp.top).offset(-LayoutLiterals.minimumHorizontalSpacing)
             make.leading.trailing.equalTo(textView)
             make.height.equalTo(62)
         }

--- a/PomoHabit/PomoHabit/Global/Components/Modal/Views/WhiteNoiseViewController.swift
+++ b/PomoHabit/PomoHabit/Global/Components/Modal/Views/WhiteNoiseViewController.swift
@@ -11,7 +11,7 @@ import SnapKit
 
 // MARK: - WhiteNoiseView
 
-final class WhiteNoiseView: BaseView {
+final class WhiteNoiseViewController: BaseViewController {
 
     // MARK: - UI Properties
   
@@ -40,24 +40,17 @@ final class WhiteNoiseView: BaseView {
     
     // MARK: - Life Cycle
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        
+    override func viewDidLoad() {
         setAddSubViews()
         setAutoLayout()
-        backgroundColor = .red
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 }
 
 // MARK: - Layout Helpers
 
-extension WhiteNoiseView {
+extension WhiteNoiseViewController {
     private func setAddSubViews() {
-        addSubViews([navigationBar, whiteNoiseLabel, editButton, tableView])
+        view.addSubViews([navigationBar, whiteNoiseLabel, editButton, tableView])
     }
     
     private func setAutoLayout() {
@@ -89,13 +82,13 @@ extension WhiteNoiseView {
 
 // MARK: - UITableViewDelegate
 
-extension WhiteNoiseView: UITableViewDelegate {
+extension WhiteNoiseViewController: UITableViewDelegate {
     
 }
 
 // MARK: - UITableViewDataSource
 
-extension WhiteNoiseView: UITableViewDataSource {
+extension WhiteNoiseViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return tempModel.count
     }

--- a/PomoHabit/PomoHabit/Presentation/Mypage/Controllers/MypageViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Mypage/Controllers/MypageViewController.swift
@@ -35,7 +35,8 @@ final class MyPageViewController: UIViewController, BottomSheetPresentable {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        presentBottomSheet(rootView: nicknameEditView, detents: [.large()])
+        presentBottomSheet(viewController: UIViewController())
+//        presentBottomSheet(rootView: nicknameEditView, detents: [.large()])
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
@@ -400,6 +400,6 @@ extension OnboardingHabitRegisterViewController {
         
         CoreDataManager.shared.createUser(nickname: data.nickname, targetHabit: data.targetHabit, targetDate: data.targetDate, alarmTime: data.alarmTime, whiteNoiseType: data.whiteNoiseType)
         
-        CoreDataManager.shared.setMockupTotalHabitInfo(today: Date(), targetDate: data.targetDate)
+        CoreDataManager.shared.setMockupTotalHabitInfo(targetDate: data.targetDate)
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -109,10 +109,11 @@ extension ReportViewController {
             button.setImage(.verticalMenu, for: .normal)
             
             let habitInfo = UIAction(title: "습관 정보", handler: { _ in
-                self.presentBottomSheet(rootView: ReportHabitInfoView(frame: .null,
-                                                                      daysButtonSelectionState: self.getMonthData(),
-                                                                      startTime: self.user?.alarmTime?.timeToString()),
-                                        detents: [.medium()])
+                self.presentBottomSheet(viewController: UIViewController())
+//                self.presentBottomSheet(rootView: ReportHabitInfoView(frame: .null,
+//                                                                      daysButtonSelectionState: self.getMonthData(),
+//                                                                      startTime: self.user?.alarmTime?.timeToString()),
+//                                        detents: [.medium()])
             })
             
             let habitEdit = UIAction(title: "습관 변경", attributes: .destructive, handler: { _ in
@@ -162,7 +163,8 @@ extension ReportViewController {
                 let boxView = UIButton(type: .system, primaryAction: .init(handler: { _ in
                     let reportHabitDetailView = ReportHabitDetailView(frame: .zero, self.totalHabitInfItems?[day])
                     reportHabitDetailView.reportViewController = self
-                    self.presentBottomSheet(rootView: reportHabitDetailView, detents: [.large()])
+//                    self.presentBottomSheet(rootView: reportHabitDetailView, detents: [.large()])
+                    self.presentBottomSheet(viewController: UIViewController())
                 }))
                 boxView.backgroundColor = .pobitRed
                 boxView.layer.cornerRadius = 10

--- a/PomoHabit/PomoHabit/Presentation/Timer/ViewControllers/PomoViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/ViewControllers/PomoViewController.swift
@@ -45,7 +45,7 @@ extension TimerViewController {
         output.memoButtonAction
             .sink { _ in
                 DispatchQueue.main.async {
-                    self.presentBottomSheet(rootView: MemoView())
+                    self.presentBottomSheet(viewController: MemoViewController())
                 }
             }
             .store(in: &cancellables)
@@ -53,7 +53,7 @@ extension TimerViewController {
         output.whiteNoiseButtonAction
             .sink { _ in
                 DispatchQueue.main.async {
-                    self.presentBottomSheet(rootView: WhiteNoiseView(), detents: [.medium()])
+                    self.presentBottomSheet(viewController: WhiteNoiseViewController(), detents: [.medium()])
                 }
             }
             .store(in: &cancellables)


### PR DESCRIPTION
##  작업한 내용
* bottomSheetPresentable 수정
* 다른 뷰컨에서 쓰이는 메서드들 주석처리 후 기본값 넣어놓기

##  PR Point
* bottomSheetPresentable에 presentBottomSheet() 메서드 보면 배경색 흰색으로 넣어주고 있어서 viewController에서 넣지 않으셔도 됩니다!
```swift
    func presentBottomSheet(viewController: UIViewController, detents: [UISheetPresentationController.Detent] = [.large()], prefersGrabberVisible: Bool = true) {
        let viewController = viewController
        viewController.view.backgroundColor = .pobitWhite
        
        guard let sheet = viewController.sheetPresentationController else { return }
        setupSheet(sheet, with: detents, prefersGrabberVisible: prefersGrabberVisible)
        
        present(viewController, animated: true)
    }
```

수정 후 파라메터값 변경에 따라 빌드 에러가 나는 이유로 presentBottomSheet()에 기본값 넣어놨으니 viewController로 수정하시고 인자값 바꿔주시면 돼요!

```swift
self.presentBottomSheet(viewController: UIViewController())
```

## 스크린샷
* 바뀌는 부분이 없어서 생략하겠습니다.

## 관련 이슈

- Resolved: #79 
