### PR TITLE
[Chore] #82 - iphone SE 기기대응

### DIFF
--- a/PomoHabit/PomoHabit/Global/Components/TabBarController.swift
+++ b/PomoHabit/PomoHabit/Global/Components/TabBarController.swift
@@ -52,7 +52,7 @@ extension TabBarController {
     
     private func adjustTabBarIconPositionBasedOnDevice() {
         let hasNotch = view.hasNotch
-        let yOffset: CGFloat = hasNotch ? 8 : -8
+        let yOffset: CGFloat = hasNotch ? 8 : -4
         
         adjustTabBarItemPosition(yOffset: yOffset)
     }

--- a/PomoHabit/PomoHabit/Global/Components/TabBarController.swift
+++ b/PomoHabit/PomoHabit/Global/Components/TabBarController.swift
@@ -22,7 +22,7 @@ final class TabBarController: UITabBarController {
         super.viewDidLoad()
         
         setTabBar()
-        adjustTabBarItemPosition(yOffset: 8)
+        adjustTabBarIconPositionBasedOnDevice()
     }
 }
 
@@ -40,13 +40,20 @@ extension TabBarController {
     }
     
     private func adjustTabBarItemPosition(yOffset: CGFloat) {
-            guard let items = self.tabBar.items else { return }
-
-            for item in items {
-                // 이미지 인셋 조정으로 아이템의 위치 변경
-                item.imageInsets = UIEdgeInsets(top: yOffset, left: 0, bottom: -yOffset, right: 0)
-                // 타이틀 위치 조정
-                item.titlePositionAdjustment = UIOffset(horizontal: 0, vertical: yOffset)
-            }
+        guard let items = self.tabBar.items else { return }
+        
+        for item in items {
+            // 이미지 인셋 조정으로 인한 아이템의 위치 변경
+            item.imageInsets = UIEdgeInsets(top: yOffset, left: 0, bottom: -yOffset, right: 0)
+            // 타이틀 위치 조정
+            item.titlePositionAdjustment = UIOffset(horizontal: 0, vertical: yOffset)
         }
+    }
+    
+    private func adjustTabBarIconPositionBasedOnDevice() {
+        let hasNotch = view.hasNotch
+        let yOffset: CGFloat = hasNotch ? 8 : -8
+        
+        adjustTabBarItemPosition(yOffset: yOffset)
+    }
 }

--- a/PomoHabit/PomoHabit/Global/Extensions/UIView+Extension.swift
+++ b/PomoHabit/PomoHabit/Global/Extensions/UIView+Extension.swift
@@ -21,4 +21,16 @@ extension UIView {
         
         return view
     }
+    
+    var hasNotch: Bool {
+        if #available(iOS 11.0, *) {
+            return safeAreaInsets.top > 20
+        }
+        return false
+    }
+    
+    /// Constraint 설정 시 노치 유무로 기기 대응
+    func constraintByNotch(_ hasNotch: CGFloat, _ noNotch: CGFloat) -> CGFloat {
+        return self.hasNotch ? hasNotch : noNotch
+    }
 }

--- a/PomoHabit/PomoHabit/Global/Extensions/UIView+Extension.swift
+++ b/PomoHabit/PomoHabit/Global/Extensions/UIView+Extension.swift
@@ -23,10 +23,7 @@ extension UIView {
     }
     
     var hasNotch: Bool {
-        if #available(iOS 11.0, *) {
-            return safeAreaInsets.top > 20
-        }
-        return false
+        return !( (UIScreen.main.bounds.width / UIScreen.main.bounds.height) > 0.5 )
     }
     
     /// Constraint 설정 시 노치 유무로 기기 대응

--- a/PomoHabit/PomoHabit/Presentation/Timer/Views/PomoProgressBar.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Views/PomoProgressBar.swift
@@ -24,10 +24,10 @@ final class CircleProgressBar: BaseView {
     
     private var todayLabel = UILabel().setPrimaryColorLabel(text: "오늘")
     
-    private let timeLabel: UILabel = {
+    private lazy var timeLabel: UILabel = {
         let label = UILabel()
         label.textColor = .pobitBlack
-        label.font = Pretendard.bold(size: 44)
+        label.font = Pretendard.bold(size: constraintByNotch(44, 32))
         label.text = "05:00"
         
         return label
@@ -62,7 +62,7 @@ extension CircleProgressBar {
     
     private func setAutoLayout() {
         todayLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(96)
+            make.top.equalToSuperview().offset(constraintByNotch(96, 84))
             make.centerX.equalToSuperview()
         }
         
@@ -118,7 +118,7 @@ extension CircleProgressBar {
         layer.strokeColor = strokeColor.cgColor
         layer.strokeEnd = strokeEnd
         layer.fillColor = UIColor.clear.cgColor
-        layer.lineWidth = 40
+        layer.lineWidth = constraintByNotch(40, 36)
         layer.lineCap = .round
         
         return layer

--- a/PomoHabit/PomoHabit/Presentation/Timer/Views/PomoView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Views/PomoView.swift
@@ -111,7 +111,7 @@ extension TimerView {
         }
         
         timerHeaderView.snp.makeConstraints { make in
-            make.top.equalTo(navigationBar.snp.bottom).offset(24)
+            make.top.equalTo(navigationBar.snp.bottom).offset(constraintByNotch(24, 12))
             make.leading.trailing.equalToSuperview().inset(LayoutLiterals.minimumHorizontalSpacing)
             make.height.equalTo(152)
         }
@@ -119,20 +119,20 @@ extension TimerView {
         setupTimerHeaderView()
         
         starView.snp.makeConstraints { make in
-            make.top.equalTo(timerHeaderView.snp.bottom).offset(36)
+            make.top.equalTo(timerHeaderView.snp.bottom).offset(constraintByNotch(36, 12))
             make.centerX.equalToSuperview()
             make.width.equalTo(120)
             make.height.equalTo(72)
         }
         
         circleProgressBar.snp.makeConstraints { make in
-            make.top.equalTo(timerHeaderView.snp.bottom).offset(68)
+            make.top.equalTo(timerHeaderView.snp.bottom).offset(constraintByNotch(68, 44))
             make.centerX.equalToSuperview()
-            make.size.equalTo(280)
+            make.size.equalTo(constraintByNotch(280, 240))
         }
         
         timerButton.snp.makeConstraints { make in
-            make.top.equalTo(circleProgressBar.snp.bottom).offset(LayoutLiterals.lowerPrimarySpacing)
+            make.top.equalTo(circleProgressBar.snp.bottom).offset(constraintByNotch(24, 12))
             make.centerX.equalToSuperview()
             make.width.equalTo(134)
             make.height.equalTo(58)


### PR DESCRIPTION
##  작업한 내용
* iphone SE 기기대응
##  PR Point
* 저희레이아웃이 se말고는 다 잘 잡히고 있어서 notch 유무로 레이아웃 상수를 따로 넣어주는 방식으로 타이머 뷰의 기기대응을 진행했습니다. 다른 분들은 레이아웃이 너무 깔끔해서 건드릴게 없네요..ㅎㅎ

## 스크린샷

|뷰|설명|
|------|---|
|   ![image](https://github.com/PlanLit/PomoHabit/assets/97212841/41e48216-7241-4394-9136-4ebdedcea822)  |  아이폰 se  |
|  ![image](https://github.com/PlanLit/PomoHabit/assets/97212841/88dfac1a-bb8e-4528-823d-b7663b6dfae4)  |  아이폰 13 mini  |

## 관련 이슈

- Resolved: #82 
