### PR TITLE
[Feat] #96 - 리포트뷰 디자인 피드백 수정 및 게이지 관련 뷰 구현

### DIFF
--- a/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
+++ b/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		E0C5B5442B8D5D9A00A77BAE /* HStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5B5412B8D5D9900A77BAE /* HStackView.swift */; };
 		E0C5B5452B8D5D9A00A77BAE /* VStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5B5422B8D5D9A00A77BAE /* VStackView.swift */; };
 		E0C5B5472B8D63B200A77BAE /* DayButtonsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C5B5462B8D63B200A77BAE /* DayButtonsTableViewCell.swift */; };
+		E0F29C162BAAB6AA00DEA573 /* CircleGaugeImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F29C152BAAB6AA00DEA573 /* CircleGaugeImageView.swift */; };
 		F85F8F572B8DE33C00E69922 /* BasePaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85F8F562B8DE33C00E69922 /* BasePaddingLabel.swift */; };
 		F85F8F592B8DE54F00E69922 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85F8F582B8DE54F00E69922 /* Date+Extension.swift */; };
 		F85F8F5B2B8DF0D500E69922 /* WeeklyCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85F8F5A2B8DF0D500E69922 /* WeeklyCollectionViewCell.swift */; };
@@ -145,6 +146,7 @@
 		E0C5B5412B8D5D9900A77BAE /* HStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HStackView.swift; sourceTree = "<group>"; };
 		E0C5B5422B8D5D9A00A77BAE /* VStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VStackView.swift; sourceTree = "<group>"; };
 		E0C5B5462B8D63B200A77BAE /* DayButtonsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayButtonsTableViewCell.swift; sourceTree = "<group>"; };
+		E0F29C152BAAB6AA00DEA573 /* CircleGaugeImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleGaugeImageView.swift; sourceTree = "<group>"; };
 		F85F8F562B8DE33C00E69922 /* BasePaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePaddingLabel.swift; sourceTree = "<group>"; };
 		F85F8F582B8DE54F00E69922 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		F85F8F5A2B8DF0D500E69922 /* WeeklyCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -550,6 +552,7 @@
 			children = (
 				F8A4FB902B96F2A300E46EA1 /* HabitInfo */,
 				E004EA602BA2497A000AD37C /* HabitIndicatorView.swift */,
+				E0F29C152BAAB6AA00DEA573 /* CircleGaugeImageView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -667,6 +670,7 @@
 				E09640092B9A63730075C2D0 /* OnboardingDatePickerTableViewCell.swift in Sources */,
 				376B91BA2B8CE6B6004CBB16 /* PobitButton.swift in Sources */,
 				BAFEE1502B96F848009F0D25 /* MypageViewController.swift in Sources */,
+				E0F29C162BAAB6AA00DEA573 /* CircleGaugeImageView.swift in Sources */,
 				F85F8F592B8DE54F00E69922 /* Date+Extension.swift in Sources */,
 				E0C5B5452B8D5D9A00A77BAE /* VStackView.swift in Sources */,
 				F85F8F612B8E25EE00E69922 /* WeeklyCalendarHabitInfoView.swift in Sources */,

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportImageCollectionViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportImageCollectionViewController.swift
@@ -68,7 +68,7 @@ extension ReportImageCollectionViewController {
         cell.contentView.addSubview(circleGaugeImageView)
     }
     
-    func setDate(_ habitAcheivementRate: Int) {
+    func setData(_ habitAcheivementRate: Int) {
         self.habitAcheivementRate = habitAcheivementRate
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportImageCollectionViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportImageCollectionViewController.swift
@@ -14,7 +14,7 @@ final class ReportImageCollectionViewController: UICollectionViewController {
     // MARK: - Properties
     
     private let cellID = "reportImageCell"
-    private let itemSize: Int = 74
+    private let itemSize: CGFloat = 100.0 - 18.0
     private var centeredItemIndex: IndexPath = [0, 0]
     
     // MARK: - Life Cycles
@@ -53,24 +53,18 @@ extension ReportImageCollectionViewController {
     }
     
     private func configureCell(_ cell: UICollectionViewCell, for indexPath: IndexPath) {
-        let imageView: UIImageView = {
-            let imageView = UIImageView(frame: cell.bounds)
-            imageView.image = .tomatoCharacter
-            imageView.contentMode = .scaleAspectFit
-            imageView.layer.cornerRadius = imageView.frame.height / 2
-            imageView.clipsToBounds = true
-            
-            return imageView
-        }()
+        let circleGaugeImageView = CircleGaugeImageView(frame: cell.bounds)
+        circleGaugeImageView.setProgress(to: 0.75, withAnimation: true)
+        circleGaugeImageView.setImage(.tomatoCharacter)
         
         if indexPath != centeredItemIndex {
             let reducedSize = itemSize-(itemSize/7)
-            imageView.frame.size = .init(width: reducedSize, height: reducedSize)
-            imageView.alpha = 0.5
+            circleGaugeImageView.frame.size = .init(width: reducedSize, height: reducedSize)
+            circleGaugeImageView.alpha = 0.5
         }
         
         cell.contentView.subviews.forEach { $0.removeFromSuperview() }
-        cell.contentView.addSubview(imageView)
+        cell.contentView.addSubview(circleGaugeImageView)
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportImageCollectionViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportImageCollectionViewController.swift
@@ -16,6 +16,7 @@ final class ReportImageCollectionViewController: UICollectionViewController {
     private let cellID = "reportImageCell"
     private let itemSize: CGFloat = 100.0 - 18.0
     private var centeredItemIndex: IndexPath = [0, 0]
+    private var habitAcheivementRate: Int = 0
     
     // MARK: - Life Cycles
     
@@ -54,7 +55,7 @@ extension ReportImageCollectionViewController {
     
     private func configureCell(_ cell: UICollectionViewCell, for indexPath: IndexPath) {
         let circleGaugeImageView = CircleGaugeImageView(frame: cell.bounds)
-        circleGaugeImageView.setProgress(to: 0.75, withAnimation: true)
+        circleGaugeImageView.setProgress(to: CGFloat(habitAcheivementRate)/CGFloat(100), withAnimation: true)
         circleGaugeImageView.setImage(.tomatoCharacter)
         
         if indexPath != centeredItemIndex {
@@ -65,6 +66,10 @@ extension ReportImageCollectionViewController {
         
         cell.contentView.subviews.forEach { $0.removeFromSuperview() }
         cell.contentView.addSubview(circleGaugeImageView)
+    }
+    
+    func setDate(_ habitAcheivementRate: Int) {
+        self.habitAcheivementRate = habitAcheivementRate
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -171,6 +171,7 @@ extension ReportViewController {
     
     private func makeImageCollectionViewController() -> ReportImageCollectionViewController {
         let imageCollectionViewController = ReportImageCollectionViewController(collectionViewLayout: UICollectionViewFlowLayout())
+        imageCollectionViewController.setDate(getHabitAchievementRate())
         imageCollectionViewController.didMove(toParent: self)
         
         return imageCollectionViewController
@@ -183,7 +184,7 @@ extension ReportViewController {
         title.textAlignment = .center
         
         let rate = UILabel()
-        rate.text = "75%"
+        rate.text = "\(getHabitAchievementRate())%"
         rate.font = Pretendard.regular(size: 16)
         rate.textAlignment = .center
         
@@ -363,6 +364,17 @@ extension ReportViewController {
         }
         
         return days
+    }
+    
+    // 달성률 구하는 함수
+    private func getHabitAchievementRate() -> Int {
+        guard let totalHabitInfItems = totalHabitInfItems else { return 0 }
+        
+        var hasDoneCount: Double = 0
+        totalHabitInfItems.forEach { habit in if habit.hasDone { hasDoneCount += 1.0 } }
+        hasDoneCount = hasDoneCount/Double(totalHabitInfItems.count) * 100
+        
+        return Int(hasDoneCount)
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -74,7 +74,7 @@ extension ReportViewController {
         imageCollectionViewController.view.snp.makeConstraints { make in
             make.top.equalTo(headerView.snp.bottom).offset(LayoutLiterals.minimumVerticalSpacing)
             make.left.right.equalToSuperview()
-            make.height.equalTo(74)
+            make.height.equalTo(100)
         }
         
         gridView.snp.makeConstraints { make in

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -87,7 +87,7 @@ extension ReportViewController {
         gridView.snp.makeConstraints { make in
             make.top.equalTo(habitAchievementLabelView.snp.bottom).offset(LayoutLiterals.minimumVerticalSpacing)
             make.centerX.equalToSuperview()
-            make.height.equalTo(45*5+(10*4))
+            make.height.equalTo(45 * 5 + (10 * 4))
         }
         
         habitIndicatorView.snp.makeConstraints { make in
@@ -374,7 +374,7 @@ extension ReportViewController {
         
         var hasDoneCount: Double = 0
         totalHabitInfItems.forEach { habit in if habit.hasDone { hasDoneCount += 1.0 } }
-        hasDoneCount = hasDoneCount/Double(totalHabitInfItems.count) * 100
+        hasDoneCount = hasDoneCount / Double(totalHabitInfItems.count) * 100
         
         return Int(hasDoneCount)
     }

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -21,9 +21,10 @@ final class ReportViewController: BaseViewController, BottomSheetPresentable {
     private let navigationBar = PobitNavigationBarView(title: "습관 달성률", viewType: .plain)
     private lazy var headerView: HStackView = makeHeaderView()
     private lazy var imageCollectionViewController: ReportImageCollectionViewController = makeImageCollectionViewController()
+    private lazy var habitAchievementLabelView: VStackView = makeHabitAchievementLabelView()
     private lazy var gridView: VStackView = makeGridView()
     private lazy var habitIndicatorView = HabitIndicatorView()
-//    private lazy var messageBoxView: UILabel = makeMessageBoxView("모두 완료하면 토마토가 웃는얼굴이 돼요")
+    private lazy var messageBoxView: UILabel = makeMessageBoxView("모두 완료하면 토마토가 웃는얼굴이 돼요")
     
     // MARK: - Life Cycles
     
@@ -51,9 +52,10 @@ extension ReportViewController {
             navigationBar,
             headerView,
             imageCollectionViewController.view,
+            habitAchievementLabelView,
             gridView,
             habitIndicatorView,
-//            messageBoxView
+            messageBoxView
         ])
     }
     
@@ -77,8 +79,13 @@ extension ReportViewController {
             make.height.equalTo(100)
         }
         
-        gridView.snp.makeConstraints { make in
+        habitAchievementLabelView.snp.makeConstraints { make in
             make.top.equalTo(imageCollectionViewController.view.snp.bottom).offset(LayoutLiterals.minimumVerticalSpacing)
+            make.centerX.equalToSuperview()
+        }
+        
+        gridView.snp.makeConstraints { make in
+            make.top.equalTo(habitAchievementLabelView.snp.bottom).offset(LayoutLiterals.minimumVerticalSpacing)
             make.centerX.equalToSuperview()
             make.height.equalTo(45*5+(10*4))
         }
@@ -90,10 +97,10 @@ extension ReportViewController {
             make.width.equalTo(250)
         }
         
-//        messageBoxView.snp.makeConstraints { make in
-//            make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-LayoutLiterals.minimumVerticalSpacing)
-//            make.centerX.equalToSuperview()
-//        }
+        messageBoxView.snp.makeConstraints { make in
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.centerX.equalToSuperview()
+        }
     }
 }
 
@@ -167,6 +174,23 @@ extension ReportViewController {
         imageCollectionViewController.didMove(toParent: self)
         
         return imageCollectionViewController
+    }
+    
+    private func makeHabitAchievementLabelView() -> VStackView {
+        let title = UILabel()
+        title.text = "달성률"
+        title.font = Pretendard.regular(size: 16)
+        title.textAlignment = .center
+        
+        let rate = UILabel()
+        rate.text = "75%"
+        rate.font = Pretendard.regular(size: 16)
+        rate.textAlignment = .center
+        
+        return VStackView(spacing: 5, alignment: .center, distribution: .fill, [
+            title,
+            rate
+        ])
     }
 
     private func makeGridView() -> VStackView {
@@ -265,15 +289,15 @@ extension ReportViewController {
             label.backgroundColor = UIColor(hex: "#FFDADA")
             label.textColor = .pobitBlack
             
-            UIView.animate(withDuration: 3,
-                           delay: 1,
+            UIView.animate(withDuration: 2,
+                           delay: 0.5,
                            usingSpringWithDamping: 0.6,
                            initialSpringVelocity: 0.2,
                            options: .curveEaseInOut) {
                 label.alpha = 1
             } completion: { _ in
-                DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                    UIView.animate(withDuration: 3,
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    UIView.animate(withDuration: 2,
                                    delay: 0,
                                    usingSpringWithDamping: 0.6,
                                    initialSpringVelocity: 0.2,

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -197,7 +197,7 @@ extension ReportViewController {
     private func makeGridView() -> VStackView {
         func getTheBoxView(_ index: Int,_ width: UInt = 56,_ height: UInt = 45) -> UIButton {
             let boxView = UIButton(type: .system, primaryAction: .init(handler: { _ in
-                if self.totalHabitInfItems![index].date?.dateToString(format: "MMdd") ?? "" <= Date().dateToString(format: "MMdd") {
+                if self.totalHabitInfItems![index].date?.dateToString(format: "MMdd") ?? "" <= Date().dateToString(format: "MMdd") && self.totalHabitInfItems![index].hasDone {
                     let reportHabitDetailViewController = ReportHabitDetailViewController()
                     reportHabitDetailViewController.setData(self.totalHabitInfItems?[index])
                     self.presentBottomSheet(viewController: reportHabitDetailViewController, detents: [.large()])

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -171,7 +171,7 @@ extension ReportViewController {
     
     private func makeImageCollectionViewController() -> ReportImageCollectionViewController {
         let imageCollectionViewController = ReportImageCollectionViewController(collectionViewLayout: UICollectionViewFlowLayout())
-        imageCollectionViewController.setDate(getHabitAchievementRate())
+        imageCollectionViewController.setData(getHabitAchievementRate())
         imageCollectionViewController.didMove(toParent: self)
         
         return imageCollectionViewController
@@ -197,9 +197,11 @@ extension ReportViewController {
     private func makeGridView() -> VStackView {
         func getTheBoxView(_ index: Int,_ width: UInt = 56,_ height: UInt = 45) -> UIButton {
             let boxView = UIButton(type: .system, primaryAction: .init(handler: { _ in
-                let reportHabitDetailViewController = ReportHabitDetailViewController()
-                reportHabitDetailViewController.setData(self.totalHabitInfItems?[index])
-                self.presentBottomSheet(viewController: reportHabitDetailViewController, detents: [.large()])
+                if self.totalHabitInfItems![index].date?.dateToString(format: "MMdd") ?? "" <= Date().dateToString(format: "MMdd") {
+                    let reportHabitDetailViewController = ReportHabitDetailViewController()
+                    reportHabitDetailViewController.setData(self.totalHabitInfItems?[index])
+                    self.presentBottomSheet(viewController: reportHabitDetailViewController, detents: [.large()])
+                }
             }))
             boxView.layer.cornerRadius = 10
             boxView.clipsToBounds = true

--- a/PomoHabit/PomoHabit/Presentation/Report/Views/CircleGaugeImageView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Views/CircleGaugeImageView.swift
@@ -1,0 +1,74 @@
+//
+//  CircleGaugeImageView.swift
+//  PomoHabit
+//
+//  Created by JiHoon K on 3/20/24.
+//
+
+import UIKit
+
+// MARK: - CircleGaugeImageView
+
+final class CircleGaugeImageView: UIView {
+    
+    // MARK: - Properties
+    
+    private var progressLayer = CAShapeLayer()
+    private var trackLayer = CAShapeLayer()
+    private var imageView = UIImageView()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUpSelf()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+// MARK: - Layout Helpers
+
+extension CircleGaugeImageView {
+    private func setUpSelf() {
+        backgroundColor = .clear
+        let circlePath = UIBezierPath(arcCenter: CGPoint(x: frame.size.width / 2.0, y: frame.size.height / 2.0), radius: (frame.size.width - 1.5) / 2, startAngle: -(.pi / 2), endAngle: 2 * .pi, clockwise: true)
+        
+        trackLayer.path = circlePath.cgPath
+        trackLayer.fillColor = UIColor.clear.cgColor
+        trackLayer.strokeColor = UIColor.systemGray6.cgColor
+        trackLayer.lineWidth = 18.0
+        trackLayer.strokeEnd = 1.0
+        layer.addSublayer(trackLayer)
+        
+        progressLayer.path = circlePath.cgPath
+        progressLayer.fillColor = UIColor.clear.cgColor
+        progressLayer.strokeColor = UIColor.pobitRed2.cgColor
+        progressLayer.lineWidth = 18.0
+        progressLayer.strokeEnd = 0.0
+        layer.addSublayer(progressLayer)
+        
+        addSubview(imageView)
+    }
+    
+    func setProgress(to progressConstant: CGFloat, withAnimation: Bool) {
+        let circularProgressAnimation = CABasicAnimation(keyPath: "strokeEnd")
+        circularProgressAnimation.duration = withAnimation ? 1 : 0
+        circularProgressAnimation.toValue = progressConstant
+        circularProgressAnimation.fillMode = .forwards
+        circularProgressAnimation.isRemovedOnCompletion = false
+        progressLayer.add(circularProgressAnimation, forKey: "progressAnim")
+    }
+    
+    func setImage(_ image: UIImage?) {
+        imageView.image = image
+        imageView.frame = CGRect(x: 0, y: 0, width: frame.size.width - 18.0, height: frame.size.height - 18.0)
+        imageView.layer.cornerRadius = imageView.frame.width / 2.0
+        imageView.clipsToBounds = true
+        imageView.center = CGPoint(x: frame.size.width / 2.0, y: frame.size.height / 2.0)
+        imageView.contentMode = .scaleAspectFit
+    }
+}

--- a/PomoHabit/PomoHabit/Presentation/Report/Views/HabitIndicatorView.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Views/HabitIndicatorView.swift
@@ -7,9 +7,15 @@
 
 import UIKit
 
+// MARK: - HabitIndicatorView
+
 final class HabitIndicatorView: UIView {
     
+    // MARK: - Properties
+    
     private lazy var container: HStackView = makeContainer()
+    
+    // MARK: - Life Cycles
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -22,6 +28,8 @@ final class HabitIndicatorView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 }
+
+// MARK: - Leyout Helpers
 
 extension HabitIndicatorView {
     private func setAddSubviews() {
@@ -36,6 +44,8 @@ extension HabitIndicatorView {
         }
     }
 }
+
+// MARK: - Fectory Methods
 
 extension HabitIndicatorView {
     private func makeContainer() -> HStackView {


### PR DESCRIPTION
##  작업한 내용
- 리포트에서 토마토 캐릭터 달성률 게이지 관련 구현
- 앱 처음 실행해서 리포트 탭 눌렀을때 한번만 띄워지는 메세지 박스 뷰 주석 품
- 리포트 습관 박스 뷰 눌렀을때 해당 일의 습관 달성했을 경우에만 눌려지게 조건문 추가
- 및 기타 코드 컨벤션

##  PR Point
- **ReportViewController**
    - **getHabitAchievementRate() -> Int:** 습관 달성률 반환하는 함수

## 스크린샷

|뷰|설명|
|------|---|
| <img width="291" alt="Screenshot 2024-03-21 at 8 25 55 AM" src="https://github.com/PlanLit/PomoHabit/assets/73418225/06af3295-82a3-4627-a6be-a4a17d3d0554"> |달성률 게이지 뷰와 하단에 한번만 띄워지는 메세지 박스 뷰|

## 관련 이슈

- Resolved: #96 
