### PR TITLE
[Feat] #102 - 온보딩 멘트 추가 및 습관 정보 없을때 튕기는 이슈 고침

### DIFF
--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
@@ -35,7 +35,7 @@ final class OnboardingHabitRegisterViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         setUpSelf()
         
         setAddSubviews()
@@ -47,6 +47,10 @@ final class OnboardingHabitRegisterViewController: BaseViewController {
         
         sayHello()
     }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
 }
 
 // MARK: - Layout Helpers
@@ -54,6 +58,9 @@ final class OnboardingHabitRegisterViewController: BaseViewController {
 extension OnboardingHabitRegisterViewController {
     private func setUpSelf() {
         view.backgroundColor = UIColor.pobitSkin
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     private func setAddSubviews() {
@@ -232,17 +239,27 @@ extension OnboardingHabitRegisterViewController {
     // 처음 채팅뷰에 진입했을때 한번만 실행시켜야함.
     private func sayHello() {
         let messages: [OnboardingChattingCellData] = [.init(chatDirection: .incoming, cellType: .profilePicture),
-                                                      .init(chatDirection: .incoming, message: "안녕 \(nickname ?? "")! 앱을 실행해 줘서 고마워!"),
-                                                      .init(chatDirection: .incoming, message: "나는 새로운 습관 형성을 도와줄 가이드야"),
+                                                      .init(chatDirection: .incoming, message: "안녕 \(nickname ?? "")!"),
+                                                      .init(chatDirection: .incoming, message: "습관 만들기 앱 PomoHabit에 오신 것을 환영해!"),
+                                                      .init(chatDirection: .incoming, message: "나는 새로운 습관 형성을 도와줄 가이드야!"),
+                                                      .init(chatDirection: .outgoing, message: "안녕~"),
+                                                      .init(chatDirection: .outgoing, message: "습관 만들기 앱이라고 들었는데?"),
+                                                      .init(chatDirection: .incoming, message: "맞아!"),
+                                                      .init(chatDirection: .incoming, message: "PomoHabit은 첫날 5분을 시작으로"),
+                                                      .init(chatDirection: .incoming, message: "매일 1분씩 증가!"),
+                                                      .init(chatDirection: .incoming, message: "21일 동안 최소 하나의 습관을"),
+                                                      .init(chatDirection: .incoming, message: "만들 수 있도록 도와주는 앱이야!"),
                                                       .init(chatDirection: .incoming, message: "어떤 습관을 만들고 싶어?")]
+        
         var index = UnsentMessagesIndex(unsentMessagesCount: messages.count)
+        
         DispatchQueue.main.async {
             self.addTableViewCellDataAndUpdate(messages[index.value])
             self.makeCountTimer(executionTargetNumber: messages.count - 1,
                                 withTimeInterval: 2,
-                                action: {
+                                action: { // messages.count - 1 만큼 실행되는 블록
                 self.addTableViewCellDataAndUpdate(messages[index.value])
-            }, ended: {
+            }, ended: { // 마지막에 한번 실행되는 블록
                 self.habitTextFieldView.isHidden = false
                 self.habitTextFieldView.subviews.first?.becomeFirstResponder()
             }).fire()
@@ -251,10 +268,10 @@ extension OnboardingHabitRegisterViewController {
     
     // 채팅 테이블뷰에 데이터와 함께 셀 추가 하는 함수
     private func addTableViewCellDataAndUpdate(_ message: OnboardingChattingCellData) {
-        self.currentMessages.append(message)
-        let indexPath = IndexPath(row: self.currentMessages.count - 1, section: 0)
-        self.chattingTableView.insertRows(at: [indexPath], with: .fade)
-        self.chattingTableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
+        currentMessages.append(message)
+        let indexPath = IndexPath(row: currentMessages.count - 1, section: 0)
+        chattingTableView.insertRows(at: [indexPath], with: .fade)
+        chattingTableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
     }
     
     // 이 함수가 호출 됬을때의 데이터 상태에따라 등록하기 버튼 뷰 패치
@@ -263,7 +280,7 @@ extension OnboardingHabitRegisterViewController {
             if habitTitle == nil { return false }
             if habitAlarmTime == nil { return false }
             var daysOnCount = 0
-            for state in self.daysButtonSelectionState {
+            for state in daysButtonSelectionState {
                 if state { daysOnCount += 1 }
             }
             if daysOnCount < 5 { return false }
@@ -308,11 +325,14 @@ extension OnboardingHabitRegisterViewController: UITableViewDataSource {
 
 extension OnboardingHabitRegisterViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if currentMessages[indexPath.row].cellType == .days {
-            return 102 + 25
+        switch currentMessages[indexPath.row].cellType {
+        case .days:
+            return 102 + 10
+        case .profilePicture:
+            return 73
+        default:
+            return 44 + 10
         }
-        
-        return 44 + 25
     }
 }
 
@@ -337,36 +357,31 @@ extension OnboardingHabitRegisterViewController: UITextFieldDelegate {
     }
 }
 
+// MARK: - Keyboard Notification
+
+extension OnboardingHabitRegisterViewController {
+    @objc func keyboardWillShow(notification: NSNotification) {
+        guard let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else {
+            return
+        }
+        
+        let contentInset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardSize.height + habitTextFieldView.frame.height, right: 0)
+        chattingTableView.contentInset = contentInset
+        chattingTableView.scrollIndicatorInsets = contentInset
+        chattingTableView.scrollToRow(at: IndexPath(row: currentMessages.count-1, section: 0), at: .bottom, animated: true)
+    }
+
+    @objc func keyboardWillHide(notification: NSNotification) {
+        chattingTableView.contentInset = .zero
+        chattingTableView.scrollIndicatorInsets = .zero
+    }
+}
+
 // MARK: - Action Helpers
 
 extension OnboardingHabitRegisterViewController {
     @objc func hideKeyboard() {
         view.endEditing(true)
-    }
-}
-
-// MARK: - Types
-
-extension OnboardingHabitRegisterViewController {
-    /// 매번 호출 되기 전 마다 1씩 증가함 + 초기에 정한 unsentMessagesCount 값 보다는 안커짐 (Index out of range Error 방지)
-    private struct UnsentMessagesIndex {
-        private let unsentMessagesCount: Int
-        private var _value: Int
-        
-        var value: Int {
-            mutating get {
-                if _value < unsentMessagesCount {
-                    _value += 1
-                }
-                
-                return _value
-            }
-        }
-        
-        init(unsentMessagesCount: Int, _value: Int = -1) {
-            self.unsentMessagesCount = unsentMessagesCount
-            self._value = _value
-        }
     }
 }
 
@@ -401,5 +416,30 @@ extension OnboardingHabitRegisterViewController {
         CoreDataManager.shared.createUser(nickname: data.nickname, targetHabit: data.targetHabit, targetDate: data.targetDate, alarmTime: data.alarmTime, whiteNoiseType: data.whiteNoiseType)
         
         CoreDataManager.shared.setMockupTotalHabitInfo(targetDate: data.targetDate)
+    }
+}
+
+// MARK: - Types
+
+extension OnboardingHabitRegisterViewController {
+    /// 매번 호출 되기 전 마다 1씩 증가함 + 초기에 정한 unsentMessagesCount 값 보다는 안커짐 (Index out of range Error 방지)
+    private struct UnsentMessagesIndex {
+        private let unsentMessagesCount: Int
+        private var _value: Int
+        
+        var value: Int {
+            mutating get {
+                if _value < unsentMessagesCount {
+                    _value += 1
+                }
+                
+                return _value
+            }
+        }
+        
+        init(unsentMessagesCount: Int, _value: Int = -1) {
+            self.unsentMessagesCount = unsentMessagesCount
+            self._value = _value
+        }
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
@@ -240,7 +240,7 @@ extension OnboardingHabitRegisterViewController {
     private func sayHello() {
         let messages: [OnboardingChattingCellData] = [.init(chatDirection: .incoming, cellType: .profilePicture),
                                                       .init(chatDirection: .incoming, message: "안녕 \(nickname ?? "")!"),
-                                                      .init(chatDirection: .incoming, message: "습관 만들기 앱 PomoHabit에 오신 것을 환영해!"),
+                                                      .init(chatDirection: .incoming, message: "습관 만들기 앱 PomoHabit에 온 것을 환영해!"),
                                                       .init(chatDirection: .incoming, message: "나는 새로운 습관 형성을 도와줄 가이드야!"),
                                                       .init(chatDirection: .outgoing, message: "안녕~"),
                                                       .init(chatDirection: .outgoing, message: "습관 만들기 앱이라고 들었는데?"),

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingChattingTableViewCell.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingChattingTableViewCell.swift
@@ -39,7 +39,6 @@ extension OnboardingChattingTableViewCell {
     
     private func setAutoLayout() {
         chattingLabel.snp.makeConstraints { make in
-            make.height.equalTo(44)
             make.centerY.equalToSuperview()
         }
     }
@@ -69,7 +68,7 @@ extension OnboardingChattingTableViewCell {
 
 extension OnboardingChattingTableViewCell {
     private func makeChattingLabel() -> BasePaddingLabel {
-        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15))
+        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 10, left: 15, bottom: 10, right: 15))
         label.font = Pretendard.medium(size: 16)
         label.backgroundColor = .pobitWhite
         label.layer.cornerRadius = 10

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -196,6 +196,9 @@ extension ReportViewController {
 
     private func makeGridView() -> VStackView {
         func getTheBoxView(_ index: Int,_ width: UInt = 56,_ height: UInt = 45) -> UIButton {
+            guard let totalHabitInfItems = self.totalHabitInfItems else { return UIButton() }
+            if totalHabitInfItems.count == 0 { return UIButton() }
+            
             let boxView = UIButton(type: .system, primaryAction: .init(handler: { _ in
                 if self.totalHabitInfItems![index].date?.dateToString(format: "MMdd") ?? "" <= Date().dateToString(format: "MMdd") && self.totalHabitInfItems![index].hasDone {
                     let reportHabitDetailViewController = ReportHabitDetailViewController()
@@ -208,7 +211,7 @@ extension ReportViewController {
             
             let label = UILabel()
             
-            if totalHabitInfItems![index].date?.dateToString(format: "MMdd") ?? "" == Date().dateToString(format: "MMdd") {
+            if totalHabitInfItems[index].date?.dateToString(format: "MMdd") ?? "" == Date().dateToString(format: "MMdd") {
                 label.text = "오늘"
                 label.font = Pretendard.bold(size: 18)
                 label.textColor = .white
@@ -220,14 +223,14 @@ extension ReportViewController {
                 }
             }
             
-            boxView.alpha = totalHabitInfItems![index].date?.dateToString(format: "MMdd") ?? "" <= Date().dateToString(format: "MMdd") ? 1 : 0.1
-            if totalHabitInfItems![index].date?.dateToString(format: "MMdd") ?? "" == Date().dateToString(format: "MMdd") &&
-                totalHabitInfItems![index].hasDone == false { // item의 날자가 오늘이고 습관 완료 안했을때 알파 값 낮춤
+            boxView.alpha = totalHabitInfItems[index].date?.dateToString(format: "MMdd") ?? "" <= Date().dateToString(format: "MMdd") ? 1 : 0.1
+            if totalHabitInfItems[index].date?.dateToString(format: "MMdd") ?? "" == Date().dateToString(format: "MMdd") &&
+                totalHabitInfItems[index].hasDone == false { // item의 날자가 오늘이고 습관 완료 안했을때 알파 값 낮춤
                 boxView.alpha = 0.1
             }
             
-            if totalHabitInfItems![index].date?.dateToString(format: "MMdd") ?? "" > Date().dateToString(format: "MMdd") ||
-                totalHabitInfItems![index].hasDone { // item의 날자가 오늘보다 미래이거나 완료 했으면 했다는 색 표시
+            if totalHabitInfItems[index].date?.dateToString(format: "MMdd") ?? "" > Date().dateToString(format: "MMdd") ||
+                totalHabitInfItems[index].hasDone { // item의 날자가 오늘보다 미래이거나 완료 했으면 했다는 색 표시
                 boxView.backgroundColor = index == 0 ? .pobitGreen : .pobitRed
             } else { // 그 외에는 안했다는거
                 boxView.backgroundColor = .pobitStone2
@@ -372,8 +375,11 @@ extension ReportViewController {
     private func getHabitAchievementRate() -> Int {
         guard let totalHabitInfItems = totalHabitInfItems else { return 0 }
         
-        var hasDoneCount: Double = 0
+        var hasDoneCount: Double = 0.0
         totalHabitInfItems.forEach { habit in if habit.hasDone { hasDoneCount += 1.0 } }
+        
+        if hasDoneCount == 0.0 { return 0 }
+        
         hasDoneCount = hasDoneCount / Double(totalHabitInfItems.count) * 100
         
         return Int(hasDoneCount)


### PR DESCRIPTION
##  작업한 내용
- 온보딩 등록 화면에서 소개 멘트 추가 및 테이블이 키보드에 가리지 않게 UX 개선
- 습관 데이터 없을때 앱 터지는거 안튕기게 예외처리

##  PR Point
- **OnboardingHabitRegisterViewController**
    - **sayHello()** 에서 멘트 추가

## 스크린샷

|뷰|설명|
|------|---|
| <img width="306" alt="Screenshot 2024-03-22 at 10 19 41 AM" src="https://github.com/PlanLit/PomoHabit/assets/73418225/c390b045-2537-43fa-b9f0-78b4e6d968fb">|  멘트 추가  |

## 관련 이슈

- Resolved: #102 
