### PR TITLE
[Fix] 주간 캘린더 화면 테스트중 오류 사항 수정

### DIFF
--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
@@ -40,16 +40,10 @@ final class WeeklyCalendarViewController: BaseViewController {
     }
     
     // MARK: - Life Cycle
-    
     override func loadView() {
         super.loadView()
         
         view = weeklyCalendarView
-    }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -73,20 +67,6 @@ final class WeeklyCalendarViewController: BaseViewController {
         super.viewDidLayoutSubviews()
         
         setUpWeeklyHabbitProgressView(progress: getWeeklyProgress())
-    }
-}
-
-// MARK: - Layout Helpers
-
-extension WeeklyCalendarViewController {
-    private func setAddSubViews() {
-        view.addSubview(weeklyCalendarView)
-    }
-    
-    private func setAutoLayout() {
-        weeklyCalendarView.snp.makeConstraints { make in
-            make.edges.equalTo(view.safeAreaLayoutGuide)
-        }
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
@@ -104,7 +104,7 @@ extension WeeklyCalendarViewController {
     private func setUpWeeklyHabbitProgressView(progress : Float) {
         if progress != 0 {
             let weeklyCalendarViewWidth = weeklyCalendarView.frame.width
-            let progressCircleOffset = Int(weeklyCalendarViewWidth * CGFloat(progress)) - 15
+            let progressCircleOffset = Int(weeklyCalendarViewWidth * CGFloat(progress)) + 5
             
             weeklyCalendarView.setProgressCircleImg(offset: progressCircleOffset)
             weeklyCalendarView.setWeeklyHabitProgressView(progress: progress)
@@ -234,6 +234,7 @@ extension WeeklyCalendarViewController {
             }
             
             weeklyCalendarView.setHabitInfoView(state: todayHabitState, targetHabit: weeklyHabitInfo.targetHabit ?? "목표 습관", duringTime: duringTime, goalTime: goalTime)
+            weeklyCalendarView.setNoteContentLabel(note: todayHabitInfo?.note ?? "메모")
         } catch {
             print(error)
         }

--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Views/WeeklyCalendarView.swift
@@ -135,17 +135,17 @@ final class WeeklyCalendarView: BaseView {
 extension WeeklyCalendarView {
     private func setAddSubViews() {
         self.addSubview(scrollView)
+        
         scrollView.addSubViews([navigationBarView,todayLabel,todayDateLabel,weeklyCollectionView,firstDivider,weeklyHabitProgressLabel,weeklyHabitProgressView,progressCircleImageView,secondDivider,habitInfoLabel,habitInfoView,thirdDivider,noteInfoLabel,noteContentLabel])
     }
     
     private func setAutoLayout() {
         scrollView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+            make.edges.equalTo(safeAreaLayoutGuide)
         }
         
         navigationBarView.snp.makeConstraints { make in
-            make.top.equalTo(safeAreaLayoutGuide)
-            make.leading.trailing.equalToSuperview()
+            make.top.leading.trailing.equalToSuperview()
         }
         
         // MARK: - 오늘 날짜 UI


### PR DESCRIPTION
##  작업한 내용
주간 캘린더 화면 테스트중 수정사항 발견
##  PR Point
App 테스트중 수정사항 발생
문제 사항 
1. 주간 캘린더 처음 진입시 오늘에 저장한 메모 출력
- 오늘 날짜를 받아오는 getTodayHabitInfo() 함수에서 아래의 코드 추가로 해당 사항 해결
`weeklyCalendarView.setNoteContentLabel(note: todayHabitInfo?.note ?? "메모")`

2. 화면의 오토레이아웃 설정 변화로 인해 주간 캘린더 스크롤 불가능 이슈
- 아래의 코드로 해결 왜 해결된지 더 학습 필요
```
scrollView.snp.makeConstraints { make in
            make.edges.equalTo(safeAreaLayoutGuide)
        }
```

3. 주간 달성률 뷰 수정으로인한 변경 사항적용

## 관련 이슈

- Resolved: #119 
