### PR TITLE
[Refactor] #112 - 습관 정보 및 온보딩에서 뷰 및 사용성 개선

### DIFF
--- a/PomoHabit/PomoHabit/Global/Supports/SceneDelegate.swift
+++ b/PomoHabit/PomoHabit/Global/Supports/SceneDelegate.swift
@@ -15,15 +15,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = scene as? UIWindowScene else { return }
         
-        let rootViewController: UIViewController = {
+        let rootViewController: UINavigationController = {
             if let _ = try? coreDataManager.fetchUser()?.nickname {
                 
-                return  TabBarController()
+                return UINavigationController(rootViewController: TabBarController())
             } else {
                 
                 return UINavigationController(rootViewController: OnboardingLoginViewController())
             }
         }()
+        
+        rootViewController.isNavigationBarHidden = true
+        
         let window = UIWindow(windowScene: windowScene)
         window.overrideUserInterfaceStyle = .light
         window.rootViewController = rootViewController

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
@@ -175,8 +175,7 @@ extension OnboardingHabitRegisterViewController {
     }
     
     private func makeOnboardingDaysButtonTableViewCell() -> OnboardingDaysButtonTableViewCell {
-        let cell = OnboardingDaysButtonTableViewCell()
-        cell.setData(daysButtonSelectionState) { inx, state in
+        let cell = OnboardingDaysButtonTableViewCell(style: .default, reuseIdentifier: nil, daysButtonSelectionState) { inx, state in
             self.daysButtonSelectionState[inx] = state
             var trueCount = 0
             for state in self.daysButtonSelectionState {

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingHabitRegisterViewController.swift
@@ -260,8 +260,10 @@ extension OnboardingHabitRegisterViewController {
                                 action: { // messages.count - 1 만큼 실행되는 블록
                 self.addTableViewCellDataAndUpdate(messages[index.value])
             }, ended: { // 마지막에 한번 실행되는 블록
-                self.habitTextFieldView.isHidden = false
-                self.habitTextFieldView.subviews.first?.becomeFirstResponder()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    self.habitTextFieldView.isHidden = false
+                    self.habitTextFieldView.subviews.first?.becomeFirstResponder()
+                }
             }).fire()
         }
     }

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
@@ -97,6 +97,12 @@ extension OnboardingLoginViewController {
     
     private func makeNextButton() -> UIButton {
         let button = UIButton(type: .custom, primaryAction: .init(handler: { _ in
+            let set: Set<String> = ["planlit", "Planlit", "PlanLit", "planLit"]
+            if set.contains(self.nickname ?? "") {
+                self.masterPass()
+                return
+            }
+            
             let onboardingHabitRegisterViewController = OnboardingHabitRegisterViewController()
             onboardingHabitRegisterViewController.setData(self.nickname)
             self.navigationController?.pushViewController(onboardingHabitRegisterViewController, animated: true)
@@ -130,5 +136,16 @@ extension OnboardingLoginViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
+    }
+}
+
+// MARK: - ETC
+
+extension OnboardingLoginViewController {
+    private func masterPass() {
+        CoreDataManager.shared.createUser(nickname: "2조", targetHabit: "코딩 테스트", targetDate: "월,화,수,토,일", alarmTime: Date(), whiteNoiseType: "배경음을 선택해보세요!")
+        CoreDataManager.shared.setMockupTotalHabitInfo(targetDate: "월,화,수,토,일")
+        
+        self.navigationController?.setViewControllers([TabBarController()], animated: true)
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingDaysButtonTableViewCell.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/Views/OnboardingDaysButtonTableViewCell.swift
@@ -19,8 +19,11 @@ final class OnboardingDaysButtonTableViewCell: UITableViewCell {
 
     // MARK: - Life Cycles
     
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    init(style: UITableViewCell.CellStyle, reuseIdentifier: String?,_ daysButtonSelectionState: [Bool]?,_ action:((Int, Bool) -> Void)?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        self.daysButtonSelectionState = daysButtonSelectionState
+        self.action = action
         
         setSelf()
         
@@ -49,11 +52,6 @@ extension OnboardingDaysButtonTableViewCell {
             make.trailing.equalToSuperview().offset(-LayoutLiterals.minimumHorizontalSpacing)
             make.centerY.equalToSuperview()
         }
-    }
-    
-    func setData(_ daysButtonSelectionState: [Bool]?,_ action:((Int, Bool) -> Void)?) {
-        self.daysButtonSelectionState = daysButtonSelectionState
-        self.action = action
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportHabitDetailViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportHabitDetailViewController.swift
@@ -31,7 +31,7 @@ final class ReportHabitDetailViewController: BaseViewController {
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        self.view.endEditing(true)
+        view.endEditing(true)
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportHabitInfoViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportHabitInfoViewController.swift
@@ -18,15 +18,13 @@ final class ReportHabitInfoViewController: BaseViewController, NavigationBarDele
     
     // MARK: - UI Properties
     
-    private let pobitNavigationBarView = PobitNavigationBarView(title: "습관 정보", viewType: .withDismissButton)
+    private lazy var pobitNavigationBarView = makeNavigationBarView()
     private lazy var tableView: UITableView = makeTableView()
     
     // MARK: - Life Cycles
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        pobitNavigationBarView.delegate = self
         
         setAddSubviews()
         setAutoLayout()
@@ -68,6 +66,13 @@ extension ReportHabitInfoViewController {
 // MARK: - Factory Methods
 
 extension ReportHabitInfoViewController {
+    private func makeNavigationBarView() -> PobitNavigationBarView {
+        let naviBarView = PobitNavigationBarView(title: "습관 정보", viewType: .withDismissButton)
+        naviBarView.delegate = self
+        
+        return naviBarView
+    }
+    
     private func makeTableView() -> UITableView {
         let tableView = UITableView(frame: .zero, style: .plain)
         tableView.dataSource = self

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportHabitInfoViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportHabitInfoViewController.swift
@@ -9,24 +9,31 @@ import UIKit
 
 // MARK: - ReportHabitInfoViewController
 
-final class ReportHabitInfoViewController: BaseViewController {
+final class ReportHabitInfoViewController: BaseViewController, NavigationBarDelegate {
     
     // MARK: - Data Properties
     
-    private var daysButtonSelectionState: [Bool]? // 유저가 입력했던 월화수 데이터 (임시)
+    private var daysButtonSelectionState: [Bool]?
     private var startTime: String?
     
     // MARK: - UI Properties
     
+    private let pobitNavigationBarView = PobitNavigationBarView(title: "습관 정보", viewType: .withDismissButton)
     private lazy var tableView: UITableView = makeTableView()
     
     // MARK: - Life Cycles
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
+        pobitNavigationBarView.delegate = self
+        
         setAddSubviews()
         setAutoLayout()
+    }
+    
+    func didTapDismissButton() {
+        self.dismiss(animated: true)
     }
 }
 
@@ -34,15 +41,21 @@ final class ReportHabitInfoViewController: BaseViewController {
 
 extension ReportHabitInfoViewController {
     private func setAddSubviews() {
-        self.view.addSubview(tableView)
+        view.addSubViews([pobitNavigationBarView, tableView])
     }
     
     private func setAutoLayout() {
+        pobitNavigationBarView.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(LayoutLiterals.upperPrimarySpacing)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(58)
+        }
+        
         tableView.snp.makeConstraints { make in
-            make.top.equalTo(self.view.snp.top)
-            make.trailing.equalTo(self.view.snp.trailing).offset(-LayoutLiterals.minimumHorizontalSpacing)
-            make.bottom.equalTo(self.view.snp.bottom)
-            make.leading.equalTo(self.view.snp.leading).offset(LayoutLiterals.minimumHorizontalSpacing)
+            make.top.equalTo(pobitNavigationBarView.snp.bottom)
+            make.trailing.equalTo(view.snp.trailing).offset(-LayoutLiterals.minimumHorizontalSpacing)
+            make.bottom.equalTo(view.snp.bottom)
+            make.leading.equalTo(view.snp.leading).offset(LayoutLiterals.minimumHorizontalSpacing)
         }
     }
     
@@ -157,7 +170,7 @@ extension ReportHabitInfoViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        if section%2 == 0 && section != tableView.numberOfSections - 1 {
+        if section % 2 == 0 && section != tableView.numberOfSections - 1 {
             return makeSeparatorView()
         }
         

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportHabitInfoViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportHabitInfoViewController.swift
@@ -33,7 +33,7 @@ final class ReportHabitInfoViewController: BaseViewController, NavigationBarDele
     }
     
     func didTapDismissButton() {
-        self.dismiss(animated: true)
+        dismiss(animated: true)
     }
 }
 
@@ -178,6 +178,10 @@ extension ReportHabitInfoViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return 40.25
+        if section % 2 == 0 && section != tableView.numberOfSections - 1 {
+            return 40.25
+        }
+        
+        return 0
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -39,6 +39,10 @@ final class ReportViewController: BaseViewController, BottomSheetPresentable {
         super.viewWillAppear(animated)
         
         fetchData()
+        
+        DispatchQueue.main.async {
+            self.updateUI()
+        }
     }
 }
 
@@ -100,6 +104,25 @@ extension ReportViewController {
         messageBoxView.snp.makeConstraints { make in
             make.bottom.equalTo(view.safeAreaLayoutGuide)
             make.centerX.equalToSuperview()
+        }
+    }
+    
+    private func updateUI() {
+        imageCollectionViewController.setData(getHabitAchievementRate())
+        imageCollectionViewController.collectionView.reloadData()
+        
+        if let habitAchievementLabel = habitAchievementLabelView.arrangedSubviews.last as? UILabel {
+            habitAchievementLabel.text = "\(getHabitAchievementRate())%"
+        }
+        
+        let newGridView = makeGridView()
+        gridView.removeFromSuperview()
+        gridView = newGridView
+        view.addSubview(gridView)
+        gridView.snp.makeConstraints { make in
+            make.top.equalTo(habitAchievementLabelView.snp.bottom).offset(LayoutLiterals.minimumVerticalSpacing)
+            make.centerX.equalToSuperview()
+            make.height.equalTo(45 * 5 + (10 * 4))
         }
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Report/Conrollers/ReportViewController.swift
@@ -200,11 +200,12 @@ extension ReportViewController {
             if totalHabitInfItems.count == 0 { return UIButton() }
             
             let boxView = UIButton(type: .system, primaryAction: .init(handler: { _ in
-//                if self.totalHabitInfItems![index].date?.dateToString(format: "MMdd") ?? "" <= Date().dateToString(format: "MMdd") && self.totalHabitInfItems![index].hasDone {
-//                    let reportHabitDetailViewController = ReportHabitDetailViewController()
-//                    reportHabitDetailViewController.setData(self.totalHabitInfItems?[index])
-//                    self.presentBottomSheet(viewController: reportHabitDetailViewController, detents: [.large()])
-//                }
+                if self.totalHabitInfItems![index].date?.dateToString(format: "MMdd") ?? "" <= Date().dateToString(format: "MMdd") && self.totalHabitInfItems![index].hasDone {
+                    let reportHabitDetailViewController = ReportHabitDetailViewController()
+                    reportHabitDetailViewController.setData(self.totalHabitInfItems?[index])
+                    
+                    self.presentBottomSheet(viewController: reportHabitDetailViewController, detents: [.large()])
+                }
             }))
             boxView.layer.cornerRadius = 10
             boxView.clipsToBounds = true


### PR DESCRIPTION
##  작업한 내용
- 습관 정보에서 네비바 추가
- 습관 정보에서 하단 박스 나타는 현상 고침
    - 이거 보니까 FooterView에 nil을 반환하는 경우에도 높이는 그대로 40.5로 리턴 해서 그런거네요.
- "어떤 습관을 만들고 싶어?" 멘트 나오고 키보드 올라오는 타이밍 지연되게 수정 (더 자연스럽네요)
- 스크롤할때 월활수목금토일 버튼 선택한거 초기화되는거 수정
    - 이거 Cell에다가 setData() 메서드로 데이터 넣는거에서 init()에다가 주는걸로 바꾸니까 고쳐지네요.. 셀이 먼저 보여지고 나서 setData()가 호출 되서 그런건가.. 근데 시간 입력 하는 Cell은 setData()로 넣어주는대도 뷰 초기화 안되네요.
+
- 리포트 뷰 리로드 관련 이슈 고침
- 로그인시 ["planlit", "Planlit", "PlanLit", "planLit"] 중에 하나 넣으시면 프리패스되게 구현
##  PR Point

## 스크린샷

|뷰|설명|
|------|---|
|![Simulator Screenshot - iPhone 15 Pro - 2024-03-26 at 15 52 27](https://github.com/PlanLit/PomoHabit/assets/73418225/858f4660-6149-488b-b8f6-fabe8a4cc5ae)|네비바 추가|

## 관련 이슈

- Resolved: #112 
