### PR TITLE
[Hotfix] 목데이터 에러사항 해결

### DIFF
--- a/PomoHabit/PomoHabit/Data/CoreData/CoreDataManager.swift
+++ b/PomoHabit/PomoHabit/Data/CoreData/CoreDataManager.swift
@@ -196,17 +196,28 @@ extension CoreDataManager {
         
         if targetDayInfos.contains(date.getDayOfWeek()){ // 오늘 습관을 진행하는 날짜인지 확인후 목데이터에 추가
             createTotalHabitInfo(date: date, goalTime: Int16(goalTime), hasDone: false, note: "")
-        }
-        
-        while appendCount != 20 {
-            date = calendar.date(byAdding: .day,value: 1, to: date) ?? Date()
-            
-            if targetDayInfos.contains(date.getDayOfWeek()) { // 습관 진행하는 요일이면 추가
-                goalTime += 1
-                createTotalHabitInfo(date: date, goalTime: Int16(goalTime), hasDone: false, note: "")
-                appendCount += 1
+            while appendCount != 20 {
+                date = calendar.date(byAdding: .day,value: 1, to: date) ?? Date()
+                
+                if targetDayInfos.contains(date.getDayOfWeek()) { // 습관 진행하는 요일이면 추가
+                    goalTime += 1
+                    createTotalHabitInfo(date: date, goalTime: Int16(goalTime), hasDone: false, note: "")
+                    appendCount += 1
+                }
+            }
+        } else {
+            while appendCount != 21 {
+                date = calendar.date(byAdding: .day,value: 1, to: date) ?? Date()
+                
+                if targetDayInfos.contains(date.getDayOfWeek()) { // 습관 진행하는 요일이면 추가
+                    goalTime += 1
+                    createTotalHabitInfo(date: date, goalTime: Int16(goalTime), hasDone: false, note: "")
+                    appendCount += 1
+                }
             }
         }
+        
+      
     }
 }
 

--- a/PomoHabit/PomoHabit/Data/CoreData/CoreDataManager.swift
+++ b/PomoHabit/PomoHabit/Data/CoreData/CoreDataManager.swift
@@ -193,31 +193,15 @@ extension CoreDataManager {
         var appendCount = 0
         var goalTime = 5
         var date = Date()
-        
-        if targetDayInfos.contains(date.getDayOfWeek()){ // 오늘 습관을 진행하는 날짜인지 확인후 목데이터에 추가
-            createTotalHabitInfo(date: date, goalTime: Int16(goalTime), hasDone: false, note: "")
-            while appendCount != 20 {
-                date = calendar.date(byAdding: .day,value: 1, to: date) ?? Date()
-                
-                if targetDayInfos.contains(date.getDayOfWeek()) { // 습관 진행하는 요일이면 추가
-                    goalTime += 1
-                    createTotalHabitInfo(date: date, goalTime: Int16(goalTime), hasDone: false, note: "")
-                    appendCount += 1
-                }
+        while appendCount != 21 {
+            if targetDayInfos.contains(date.getDayOfWeek()) { // 습관 진행하는 요일이면 추가
+                goalTime += 1
+                createTotalHabitInfo(date: date, goalTime: Int16(goalTime), hasDone: false, note: "")
+                appendCount += 1
             }
-        } else {
-            while appendCount != 21 {
-                date = calendar.date(byAdding: .day,value: 1, to: date) ?? Date()
-                
-                if targetDayInfos.contains(date.getDayOfWeek()) { // 습관 진행하는 요일이면 추가
-                    goalTime += 1
-                    createTotalHabitInfo(date: date, goalTime: Int16(goalTime), hasDone: false, note: "")
-                    appendCount += 1
-                }
-            }
+            
+            date = calendar.date(byAdding: .day,value: 1, to: date) ?? Date()
         }
-        
-      
     }
 }
 


### PR DESCRIPTION
##  작업한 내용
목데이터 에러 해결
##  PR Point
에러 발생이유 : 오늘 습관날이 아닐경우에는 목데이터를 생성해주지 않아서 20개의 목데이터가 생기는 현상 발생
해결법 : 습관을 진행하는 경우 목데이터 생성후 날짜 하루씩 증가 하는 방식으로 코드를 변경 
```swift
 while appendCount != 21 {
            if targetDayInfos.contains(date.getDayOfWeek()) { // 습관 진행하는 요일이면 추가
                goalTime += 1
                createTotalHabitInfo(date: date, goalTime: Int16(goalTime), hasDone: false, note: "")
                appendCount += 1
            }
            
            date = calendar.date(byAdding: .day,value: 1, to: date) ?? Date()
        }
```


- Resolved: HotFix로 이슈 생성하지 않았습니다.
