### PR TITLE
[Fix] #139 - 주간캘린더 선택된 날짜의 DuringTime 에러 해결

### DIFF
--- a/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/WeeklyCalendar/Controllers/WeeklyCalendarViewController.swift
@@ -235,8 +235,8 @@ extension WeeklyCalendarViewController {
                     weeklyHabitInfo.habitstate = selectedHabitInfo.hasDone ?  HabitState.done : HabitState.doNot
                     weeklyHabitInfo.goalTime = selectedHabitInfo.goalTime
                     if selectedHabitInfo.hasDone {
-                        print(date.dateToString(format: "yyyy-MM-dd HH:mm"))
-                        weeklyHabitInfo.duringTime = getDuringTime(completedDate: date, goalTime: selectedHabitInfo.goalTime)
+                        
+                        weeklyHabitInfo.duringTime = getDuringTime(completedDate: selectedHabitInfo.date ?? Date(), goalTime: selectedHabitInfo.goalTime)
                     } else {
                         weeklyHabitInfo.duringTime = "00:00 ~ 00:00"
                     }


### PR DESCRIPTION
##  작업한 내용
주간 캘린더 에러 처리
- 주간 캘린더 날짜 선택시 CoreData에 저장되어있는 완료시간으로 DuringTime 설정
##  PR Point
주간 캘린더 날짜 선택시 완료시간이 초기값임 00:00으로 설정되는 에러
에러 이유: 선택한날짜의 Date데이터를 넣지 않고 기본값인 Date()를 넣음으로써 발생함


## 관련 이슈

- Resolved: #139 
