### PR TITLE
[Chore] #135 - 로그인시 사용성 개선

### DIFF
--- a/PomoHabit/PomoHabit/Global/Extensions/UITextField+Extension.swift
+++ b/PomoHabit/PomoHabit/Global/Extensions/UITextField+Extension.swift
@@ -9,14 +9,14 @@ import UIKit
 
 extension UITextField {
     func addLeftPadding() {
-        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 48, height: self.frame.height))
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: self.frame.height))
         
         self.leftView = paddingView
         self.leftViewMode = ViewMode.always
     }
     
     func addRightPadding() {
-        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 48, height: self.frame.height))
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: self.frame.height))
         
         self.rightView = paddingView
         self.rightViewMode = ViewMode.always

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
@@ -91,6 +91,9 @@ extension OnboardingLoginViewController {
         textField.addLeftPadding()
         textField.addRightPadding()
         textField.delegate = self
+        textField.snp.makeConstraints { make in
+            make.width.equalTo(185)
+        }
         
         return textField
     }

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
@@ -103,9 +103,13 @@ extension OnboardingLoginViewController {
                 return
             }
             
-            let onboardingHabitRegisterViewController = OnboardingHabitRegisterViewController()
-            onboardingHabitRegisterViewController.setData(self.nickname)
-            self.navigationController?.pushViewController(onboardingHabitRegisterViewController, animated: true)
+            if self.checkNicknameValidity() {
+                let onboardingHabitRegisterViewController = OnboardingHabitRegisterViewController()
+                onboardingHabitRegisterViewController.setData(self.nickname)
+                self.navigationController?.pushViewController(onboardingHabitRegisterViewController, animated: true)
+            } else {
+                // 알럿 창 띄우기
+            }
         }))
         button.setImage(UIImage(named: "arrow"), for: .normal)
         button.layer.opacity = 0.5
@@ -135,6 +139,21 @@ extension OnboardingLoginViewController: UITextFieldDelegate {
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
+        return true
+    }
+}
+
+// MARK: - Helpers
+
+extension OnboardingLoginViewController {
+    /// 닉네임 글자수가 2 이상, 16 이하이면서, 공백이 없으면 true 반환
+    private func checkNicknameValidity() -> Bool {
+        guard let nickname = nickname else { return false }
+        
+        if nickname.count < 2 || nickname.count > 16 || nickname.contains(" ") {
+            return false
+        }
+        
         return true
     }
 }

--- a/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Onboarding/ViewControllers/OnboardingLoginViewController.swift
@@ -109,6 +109,9 @@ extension OnboardingLoginViewController {
                 self.navigationController?.pushViewController(onboardingHabitRegisterViewController, animated: true)
             } else {
                 // 알럿 창 띄우기
+                let alertController = UIAlertController(title: "올바른 닉네임을 입력해 주세요!", message: "2자 이상, 16자 이하, 공백 포함 불가능", preferredStyle: .alert)
+                alertController.addAction(UIAlertAction(title: "확인", style: .default, handler: { _ in }))
+                self.present(alertController, animated: true, completion: nil)
             }
         }))
         button.setImage(UIImage(named: "arrow"), for: .normal)


### PR DESCRIPTION
##  작업한 내용
1. 로그인시 닉네임이 유효한지 체크하는 함수 생성.
2. 로그인 시 올바르지 않은 닉네임으로 다음 버튼 누르면 알럿 메세지 표시 기능 추가.
3. 닉네임을 많이 적으면 닉네임 입력 뷰가 화면을 초과해서 나가는 현상 수정.
4. UITextField+Extension에서 addLeftPadding, addRightPadding의 width 값 수정.
(좌우 패딩이 너무 큰 거 같고, OnboardingLoginViewController에서 말고는 사용되고 있지 않는 거 같아서 수정했습니다.)

## 스크린샷

|뷰|설명|
|------|---|
|<img width="301" alt="Screenshot 2024-05-16 at 4 49 18 AM" src="https://github.com/PlanLit/PomoHabit/assets/73418225/bda62efe-b2a2-420f-a353-3fa38b68d53d">|닉 양식은 알럿 메시지에서 보여줌. 웬만해선 사용자가 닉 양식을 자연스럽게 지킬 것으로 예상되기 때문|

## 관련 이슈

- Resolved: #135 
