### PR TITLE
[Refactor] #132 - TimerViewModel DI

### DIFF
--- a/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
+++ b/PomoHabit/PomoHabit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3708BCBF2BB992C50089B50F /* CoreDataManagerProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3708BCBE2BB992C50089B50F /* CoreDataManagerProtocols.swift */; };
 		3709E8182BB1DD4C004EECAE /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3709E8172BB1DD4C004EECAE /* UserDefaultsManager.swift */; };
 		37144C662B8C32D6008565C4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37144C652B8C32D6008565C4 /* AppDelegate.swift */; };
 		37144C682B8C32D6008565C4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37144C672B8C32D6008565C4 /* SceneDelegate.swift */; };
@@ -85,7 +86,6 @@
 		F88EB2DC2B8DC1120073BDDA /* WeeklyCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88EB2DB2B8DC1120073BDDA /* WeeklyCalendarView.swift */; };
 		F8A179D62BAC164A005AAC18 /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = F8A179D52BAC164A005AAC18 /* Pretendard-Black.otf */; };
 		F8A4FB882B96F27B00E46EA1 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = E0F115972B901D5E003E6459 /* SnapKit */; };
-		F8A4FB892B96F27B00E46EA1 /* SnapKit-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = E0F115992B901D5E003E6459 /* SnapKit-Dynamic */; };
 		F8A4FB952B96F2A300E46EA1 /* ReportImageCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A4FB8D2B96F2A300E46EA1 /* ReportImageCollectionViewController.swift */; };
 		F8A4FB962B96F2A300E46EA1 /* ReportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A4FB8E2B96F2A300E46EA1 /* ReportViewController.swift */; };
 		F8A4FB972B96F2A300E46EA1 /* ReportDayButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A4FB912B96F2A300E46EA1 /* ReportDayButtonTableViewCell.swift */; };
@@ -97,6 +97,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3708BCBE2BB992C50089B50F /* CoreDataManagerProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManagerProtocols.swift; sourceTree = "<group>"; };
 		3709E8172BB1DD4C004EECAE /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		37144C622B8C32D6008565C4 /* PomoHabit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PomoHabit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		37144C652B8C32D6008565C4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -191,7 +192,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F8A4FB892B96F27B00E46EA1 /* SnapKit-Dynamic in Frameworks */,
 				F8A4FB882B96F27B00E46EA1 /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -265,6 +265,7 @@
 			children = (
 				37396CA82B96103C001E81F3 /* PobitModel.xcdatamodeld */,
 				37396CBB2B97823D001E81F3 /* CoreDataManager.swift */,
+				3708BCBE2BB992C50089B50F /* CoreDataManagerProtocols.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -662,7 +663,6 @@
 			name = PomoHabit;
 			packageProductDependencies = (
 				E0F115972B901D5E003E6459 /* SnapKit */,
-				E0F115992B901D5E003E6459 /* SnapKit-Dynamic */,
 			);
 			productName = PomoHabit;
 			productReference = 37144C622B8C32D6008565C4 /* PomoHabit.app */;
@@ -758,6 +758,7 @@
 				37B811CD2B9B74BE00A6694E /* InputOutputProtocol.swift in Sources */,
 				37144C6A2B8C32D6008565C4 /* ViewController.swift in Sources */,
 				378034AB2B8F9D7A0046E6B8 /* MemoViewController.swift in Sources */,
+				3708BCBF2BB992C50089B50F /* CoreDataManagerProtocols.swift in Sources */,
 				E0C5B53E2B8D5B2700A77BAE /* DayButton.swift in Sources */,
 				E0BEE14B2B99366600A2C4C4 /* OnboardingChattingCellData.swift in Sources */,
 				378034A12B8F8D830046E6B8 /* TimerViewController.swift in Sources */,
@@ -947,7 +948,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 24032802;
 				DEVELOPMENT_TEAM = 2DG35ZK3GC;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PomoHabit/Info.plist;
@@ -961,7 +962,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.PlanLit.PomoHabit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -980,7 +981,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 24032802;
 				DEVELOPMENT_TEAM = 2DG35ZK3GC;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PomoHabit/Info.plist;
@@ -994,7 +995,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.PlanLit.PomoHabit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1046,11 +1047,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E0F115962B901D5E003E6459 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
-		};
-		E0F115992B901D5E003E6459 /* SnapKit-Dynamic */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E0F115962B901D5E003E6459 /* XCRemoteSwiftPackageReference "SnapKit" */;
-			productName = "SnapKit-Dynamic";
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/PomoHabit/PomoHabit/Data/CoreData/CoreDataManager.swift
+++ b/PomoHabit/PomoHabit/Data/CoreData/CoreDataManager.swift
@@ -13,7 +13,7 @@ enum CoreDataError: Error {
 
 // MARK: - CoreDataManager
 
-final class CoreDataManager {
+final class CoreDataManager: CoreDataManagerProtocol {
     
     static let shared = CoreDataManager()
     
@@ -159,7 +159,6 @@ extension CoreDataManager {
     }
 }
 
-
 // MARK: - Timer
 
 extension CoreDataManager {
@@ -184,6 +183,7 @@ extension CoreDataManager {
         saveContext()
     }
 }
+
 // MARK: - MockData
 
 extension CoreDataManager {
@@ -274,7 +274,7 @@ extension CoreDataManager {
 // MARK: - CoreData 파일 저장 경로 얻는 함수
 
 extension CoreDataManager {
-    func getSaveCoredataPath(){
+    func getSaveCoredataPath() {
         if let documentsDirectoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last {
             print("Documents Directory: \(documentsDirectoryURL)")
         }

--- a/PomoHabit/PomoHabit/Data/CoreData/CoreDataManagerProtocols.swift
+++ b/PomoHabit/PomoHabit/Data/CoreData/CoreDataManagerProtocols.swift
@@ -1,0 +1,16 @@
+//
+//  CoreDataManagerProtocols.swift
+//  PomoHabit
+//
+//  Created by Joon Baek on 2024/03/31.
+//
+
+import Foundation
+
+protocol CoreDataManagerProtocol {
+    func fetchUser() throws -> User?
+    func updateWhiteNoiseType(with whiteNoiseType: String)
+    func completedTodyHabit(completedDate: Date, note: String)
+    func getSelectedHabitInfo(selectedDate: Date) throws -> TotalHabitInfo?
+}
+

--- a/PomoHabit/PomoHabit/Data/UserDefaults/UserDefaultsManager.swift
+++ b/PomoHabit/PomoHabit/Data/UserDefaults/UserDefaultsManager.swift
@@ -7,7 +7,12 @@
 
 import Foundation
 
-final class UserDefaultsManager {
+protocol UserDefaultsManagerProtocol {
+    func saveTimerState(_ state: TimerState)
+    func loadTimerState() -> TimerState
+}
+
+final class UserDefaultsManager: UserDefaultsManagerProtocol {
     static let shared = UserDefaultsManager()
     
     private init() {}

--- a/PomoHabit/PomoHabit/Global/Components/ViewControllerFactory.swift
+++ b/PomoHabit/PomoHabit/Global/Components/ViewControllerFactory.swift
@@ -9,7 +9,7 @@
 
 final class ViewControllerFactory {
     static func makeTimerViewController() -> TimerViewController {
-        let viewController = TimerViewController(viewModel: TimerViewModel(), rootView: TimerView())
+        let viewController = TimerViewController(viewModel: TimerViewModel(coreDataManager: CoreDataManager.shared, userDefaultsManager: UserDefaultsManager.shared), rootView: TimerView())
         
         return viewController
     }

--- a/PomoHabit/PomoHabit/Presentation/Timer/Views/TimerProgressBar.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Views/TimerProgressBar.swift
@@ -118,9 +118,7 @@ extension CircleProgressBar {
         let seconds = Int(remainingTime) % 60
         let timeString = String(format: "%02d:%02d", minutes, seconds)
         timeLabel.text = timeString
-        DispatchQueue.main.async {
-            self.timeLabel.text = String(format: "%02d:%02d", minutes, seconds)
-        }
+        self.timeLabel.text = String(format: "%02d:%02d", minutes, seconds)
     }
 }
 

--- a/PomoHabit/PomoHabit/Presentation/Timer/Views/ViewControllers/TimerViewController.swift
+++ b/PomoHabit/PomoHabit/Presentation/Timer/Views/ViewControllers/TimerViewController.swift
@@ -44,7 +44,6 @@ final class TimerViewController: BaseViewController, BottomSheetPresentable {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        
         bind()
         viewDidLoadSubject.send()
     }


### PR DESCRIPTION
##  작업한 내용
- UserDefaultsManager, CoreDataManager 주입
##  PR Point
메서드에서 shared에 접근해 처리해주던 것을 protocol을 참조하고, 생성시 shared를 넣어주는 방식으로 추상화했습니다.

### CoreDataManager 프로토콜 정의
```swift
protocol CoreDataManagerProtocol {
    func fetchUser() throws -> User?
    func updateWhiteNoiseType(with whiteNoiseType: String)
    func completedTodyHabit(completedDate: Date, note: String)
    func getSelectedHabitInfo(selectedDate: Date) throws -> TotalHabitInfo?
}
```

### init에서 dataManagers 주입
```swift
final class TimerViewModel: InputOutputProtocol {
    // MARK: - Life Cycle
    
    init(coreDataManager: CoreDataManagerProtocol, userDefaultsManager: UserDefaultsManagerProtocol) {
        self.coreDataManager = coreDataManager
        self.userDefaultsManager = userDefaultsManager
        
        getUserData()
        getSelectedDayHabitInfo(selectedDay: currentDate)
    }
}
```

### .shared가 아닌 참조하고 있는 dataManager 프로퍼티에서 직접 메서드 호출
```swift
    private func loadTimerState() {
        let timerState = userDefaultsManager.loadTimerState()
        updateState(timerState)
    }
```

### ViewControllerFactory에서 생성시 dataManagers.shared 주입
```swift
final class ViewControllerFactory {
    static func makeTimerViewController() -> TimerViewController {
        let viewController = TimerViewController(viewModel: TimerViewModel(coreDataManager: CoreDataManager.shared, userDefaultsManager: UserDefaultsManager.shared), rootView: TimerView())
        
        return viewController
    }
```

아마 여러분들이 사용하시는 메서드들을 한 프로토콜에 다 넣으면 프로토콜이 엄청 비대해질 겁니다.. 해당 부분은 CoreDataManagerProtocol를 상속받는 프로토콜들로 한번 더 추상화를 진행해서 해결해보면 좋을 것 같아요.

## 스크린샷
* 뷰가 바뀌지 않아서 생략

## 관련 이슈

- Resolved: #132 
